### PR TITLE
feat(brain): MobiAI Brain fase 1 — init/scan/context

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ Compatible con **Claude Code**, **Cursor**, **Copilot CLI**, **Codex** y **Gemin
 
 | Componente | Estado |
 |------------|--------|
-| Skills (multi-plataforma) | Disponible |
+| Skills (multi-plataforma) | Estable |
+| Brain | Alpha |
 | Agentes autónomos | En desarrollo |
 | Pipeline automatizado (bot de mensajería) | Planificado |
 | Marketplace de skills comunitarios | Planificado |
 
 ## Instalación
 
-MobiAI se organiza en plugins granulares. Instalá sólo las plataformas que uses, o instalá el meta-plugin `mobile` para todo el stack.
+MobiAI se organiza en plugins granulares. Instala sólo las plataformas que uses, o instala el meta-plugin `mobile` para todo el stack.
 
 ### Claude Code
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # MobiAI-Core
 
-El plugin de IA para desarrolladores mobile. Skills, agentes y pipelines automatizados para Android, iOS, KMP, Flutter y React Native.
+Evoluciona tu stack móvil con Inteligencia Artificial.
 
 ## ¿Qué es MobiAI?
 
-MobiAI es un ecosistema open source que potencia tu desarrollo mobile con IA. No es solo un conjunto de skills — es una plataforma completa que crece con la comunidad:
+MobiAI es un ecosistema Open Source diseñado para llevar la Inteligencia Artificial al corazón de tu flujo de trabajo. Más que una librería de funciones, es una plataforma evolutiva que automatiza lo complejo para que tú te centres en crear.
 
 - **Skills** — Contexto experto que adapta lo que la IA ya sabe al escenario adecuado. Los skills no le enseñan a programar — le dan el contexto, las herramientas y los flujos específicos de cada plataforma para que aplique su conocimiento de forma precisa. Corregir bugs, reproducir incidencias, escribir tests, analizar crashes, crear PRs... todo siguiendo las mejores prácticas de cada plataforma.
+- **Brain** - El cerebro contextual de cada proyecto: entiende tu stack mobile, recuerda decisiones, bugfixes y patrones clave, y entrega a la IA contexto preciso y filtrado para trabajar alineada con tu arquitectura, evitando ruido y ahorrando tokens.
 - **Agentes** — Agentes especializados que ejecutan tareas complejas de forma autónoma: un agente que analiza código, otro que interactúa con el dispositivo, otro que escribe tests.
 - **Pipeline automatizado** — Un flujo completo de corrección de bugs: recibe un error o ticket desde cualquier plataforma de mensajería, reproduce el bug en un emulador, encuentra la causa raíz, aplica el fix, ejecuta tests y crea el PR. Todo sin intervención humana.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ MobiAI incluye skills para todo el ciclo de desarrollo mobile:
 
 Consulta el [catálogo completo de skills](plugins/core/skills/using-mobiai/SKILL.md) para ver cuándo usar cada uno.
 
+## MobiAI Brain (preview)
+
+`mobiai brain` añade **memoria viva por proyecto** a la CLI: decisiones, bugfixes, workarounds e integraciones específicas de cada repo mobile, separadas del estado global de MobiAI.
+
+```bash
+mobiai brain init      # crea <repo>/.mobiai/brain/ (idempotente)
+mobiai brain scan      # detecta stack: Android/iOS/KMP/Flutter/RN + librerías
+mobiai brain context   # imprime Markdown listo para agentes
+```
+
+Detalle completo en [docs/brain.md](docs/brain.md). Los subcomandos `save` y `search` llegan en una próxima fase.
+
 ## ¿Cómo funciona?
 
 1. **Instala el plugin** — MobiAI registra sus skills en tu asistente de IA (Claude Code, Cursor, Copilot CLI, Codex o Gemini CLI)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para más detalles.
   <img src="https://contrib.rocks/image?repo=ArisGuimera/mobiai-core" />
 </a>
 
-## Licencia
 
-MIT — ver [LICENSE](LICENSE)
+---
+
+<div align="center">
+<a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
+</div>

--- a/cli/cmd/mobiai/main.go
+++ b/cli/cmd/mobiai/main.go
@@ -106,6 +106,7 @@ func newRootCmd(v string) *cobra.Command {
 	root.AddCommand(cmd.NewDoctorCmd())
 	root.AddCommand(cmd.NewUpdateCmd())
 	root.AddCommand(cmd.NewTelemetryCmd())
+	root.AddCommand(cmd.NewBrainCmd())
 	return root
 }
 

--- a/cli/internal/brain/config.go
+++ b/cli/internal/brain/config.go
@@ -1,0 +1,107 @@
+package brain
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ConfigVersion is the current schema version of config.json.
+// Bumped when the schema changes in a non-backwards-compatible way.
+const ConfigVersion = 1
+
+// DefaultRules is the seed set of rules written by `brain init` when no
+// config.json exists. Users edit these freely afterwards; the brain treats
+// the rules as opaque strings.
+var DefaultRules = []string{
+	"Prioritize clean architecture",
+	"Prepare code for testing",
+	"Do not introduce hacks",
+	"Respect existing project conventions",
+}
+
+// Config is the persisted shape of <brain>/config.json.
+type Config struct {
+	Version     int      `json:"version"`
+	ProjectName string   `json:"project_name"`
+	ProjectType string   `json:"project_type"`
+	Platforms   []string `json:"platforms"`
+	Rules       []string `json:"rules"`
+	CreatedAt   string   `json:"created_at"`
+	UpdatedAt   string   `json:"updated_at"`
+}
+
+// DefaultConfig returns the template used by `brain init` for a brand-new
+// project. ProjectName is filename-safe (the basename of the project root).
+func DefaultConfig(projectRoot string) Config {
+	now := nowISO()
+	return Config{
+		Version:     ConfigVersion,
+		ProjectName: filepath.Base(projectRoot),
+		ProjectType: ProjectTypeUnknown,
+		Platforms:   []string{},
+		Rules:       append([]string(nil), DefaultRules...),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+}
+
+// LoadConfig reads <brain>/config.json. Returns os.ErrNotExist if missing.
+func LoadConfig(p BrainPaths) (Config, error) {
+	data, err := os.ReadFile(p.ConfigFile)
+	if err != nil {
+		return Config{}, err
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Config{}, fmt.Errorf("parse %s: %w", p.ConfigFile, err)
+	}
+	return c, nil
+}
+
+// Save writes <brain>/config.json atomically (temp + rename).
+func (c *Config) Save(p BrainPaths) error {
+	c.UpdatedAt = nowISO()
+	if err := os.MkdirAll(p.Dir, 0o755); err != nil {
+		return fmt.Errorf("crear %s: %w", p.Dir, err)
+	}
+	return writeJSONAtomic(p.ConfigFile, c)
+}
+
+// nowISO returns the current time in RFC3339 UTC. Wrapped so tests can
+// freeze it via timeNow.
+var timeNow = time.Now
+
+func nowISO() string {
+	return timeNow().UTC().Format(time.RFC3339)
+}
+
+// writeJSONAtomic mirrors the temp+rename pattern in state/installed.go so
+// we never leave a half-written JSON file on disk.
+func writeJSONAtomic(path string, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("tmp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename → %s: %w", path, err)
+	}
+	return nil
+}

--- a/cli/internal/brain/context.go
+++ b/cli/internal/brain/context.go
@@ -37,7 +37,10 @@ func BuildContext(cfg Config, scan *Scan, p BrainPaths) string {
 	fmt.Fprintf(&b, "Type: %s\n", projectTypeLabel(cfg.ProjectType))
 	if scan != nil && cfg.ProjectType == ProjectTypeUnknown && scan.ProjectType != ProjectTypeUnknown {
 		// scan has a fresher answer than config — show both so the user
-		// notices and re-runs `brain init` if they want config refreshed.
+		// notices the drift. To refresh config, re-run `mobiai brain
+		// scan` (which auto-fills project_type/platforms when they're
+		// at defaults) or edit config.json by hand. `brain init` is
+		// idempotent and will NOT overwrite the existing config.
 		fmt.Fprintf(&b, "Type (scan): %s\n", projectTypeLabel(scan.ProjectType))
 	}
 	platforms := cfg.Platforms

--- a/cli/internal/brain/context.go
+++ b/cli/internal/brain/context.go
@@ -108,10 +108,11 @@ func writeRulesSection(b *strings.Builder, cfg Config) {
 func writeMemorySection(b *strings.Builder, p BrainPaths, mf MemoryFile) {
 	body := readMemory(p, mf.Name)
 	body = stripLeadingTitle(body)
+	body = stripHTMLComments(body)
 	body = strings.TrimSpace(body)
 
 	fmt.Fprintf(b, "%s\n\n", mf.ContextHead)
-	if body == "" || onlyHTMLComments(body) {
+	if body == "" {
 		b.WriteString("_No entries yet._\n\n")
 		return
 	}
@@ -132,22 +133,22 @@ func stripLeadingTitle(content string) string {
 	return ""
 }
 
-// onlyHTMLComments returns true if the (trimmed) content has no real
-// prose — only the `<!-- ... -->` placeholder we wrote at init time.
-func onlyHTMLComments(content string) bool {
-	stripped := content
+// stripHTMLComments removes every `<!-- ... -->` block from content.
+// Used to drop the init-time placeholders before printing a section
+// (they're meant for whoever opens the .md, not for the context dump).
+func stripHTMLComments(content string) string {
 	for {
-		start := strings.Index(stripped, "<!--")
+		start := strings.Index(content, "<!--")
 		if start < 0 {
-			break
+			return content
 		}
-		end := strings.Index(stripped[start:], "-->")
+		rest := content[start:]
+		end := strings.Index(rest, "-->")
 		if end < 0 {
-			break
+			return content
 		}
-		stripped = stripped[:start] + stripped[start+end+3:]
+		content = content[:start] + content[start+end+3:]
 	}
-	return strings.TrimSpace(stripped) == ""
 }
 
 func writeWarningsSection(b *strings.Builder, scan *Scan) {

--- a/cli/internal/brain/context.go
+++ b/cli/internal/brain/context.go
@@ -1,0 +1,162 @@
+package brain
+
+import (
+	"fmt"
+	"strings"
+)
+
+// projectTypeLabel returns a human-friendly name for a project_type
+// value. Falls back to the raw value when unknown.
+func projectTypeLabel(t string) string {
+	switch t {
+	case ProjectTypeAndroid:
+		return "Android"
+	case ProjectTypeIOS:
+		return "iOS"
+	case ProjectTypeKMP:
+		return "Kotlin Multiplatform"
+	case ProjectTypeFlutter:
+		return "Flutter"
+	case ProjectTypeReactNative:
+		return "React Native"
+	case ProjectTypeUnknown, "":
+		return "Unknown"
+	default:
+		return t
+	}
+}
+
+// BuildContext assembles the Markdown context document consumed by AI
+// agents. It is intentionally close to the spec layout — section names
+// and order matter because skills/agents grep for them.
+func BuildContext(cfg Config, scan *Scan, p BrainPaths) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "# MobiAI Brain Context\n\n")
+	fmt.Fprintf(&b, "Project: %s\n", cfg.ProjectName)
+	fmt.Fprintf(&b, "Type: %s\n", projectTypeLabel(cfg.ProjectType))
+	if scan != nil && cfg.ProjectType == ProjectTypeUnknown && scan.ProjectType != ProjectTypeUnknown {
+		// scan has a fresher answer than config — show both so the user
+		// notices and re-runs `brain init` if they want config refreshed.
+		fmt.Fprintf(&b, "Type (scan): %s\n", projectTypeLabel(scan.ProjectType))
+	}
+	platforms := cfg.Platforms
+	if len(platforms) == 0 && scan != nil {
+		platforms = scan.Platforms
+	}
+	if len(platforms) > 0 {
+		fmt.Fprintf(&b, "Platforms: %s\n", strings.Join(platforms, ", "))
+	}
+	b.WriteString("\n")
+
+	writeStackSection(&b, scan)
+	writeRulesSection(&b, cfg)
+
+	for _, mf := range MemoryFiles {
+		writeMemorySection(&b, p, mf)
+	}
+
+	writeWarningsSection(&b, scan)
+	return b.String()
+}
+
+func writeStackSection(b *strings.Builder, scan *Scan) {
+	b.WriteString("## Detected Stack\n\n")
+	if scan == nil {
+		b.WriteString("_No scan yet. Run `mobiai brain scan`._\n\n")
+		return
+	}
+	any := false
+	for _, row := range []struct {
+		label string
+		items []string
+	}{
+		{"UI", scan.UI},
+		{"DI", scan.DI},
+		{"Network", scan.Network},
+		{"Persistence", scan.Persistence},
+		{"Serialization", scan.Serialization},
+		{"Testing", scan.Testing},
+		{"Integrations", scan.Integrations},
+		{"CI/CD", scan.CICD},
+		{"Build systems", scan.BuildSystems},
+	} {
+		if len(row.items) == 0 {
+			continue
+		}
+		any = true
+		fmt.Fprintf(b, "- %s: %s\n", row.label, strings.Join(row.items, ", "))
+	}
+	if !any {
+		b.WriteString("_No technologies detected yet._\n")
+	}
+	b.WriteString("\n")
+}
+
+func writeRulesSection(b *strings.Builder, cfg Config) {
+	b.WriteString("## Project Rules\n\n")
+	if len(cfg.Rules) == 0 {
+		b.WriteString("_No rules defined._\n\n")
+		return
+	}
+	for _, r := range cfg.Rules {
+		fmt.Fprintf(b, "- %s\n", r)
+	}
+	b.WriteString("\n")
+}
+
+func writeMemorySection(b *strings.Builder, p BrainPaths, mf MemoryFile) {
+	body := readMemory(p, mf.Name)
+	body = stripLeadingTitle(body)
+	body = strings.TrimSpace(body)
+
+	fmt.Fprintf(b, "%s\n\n", mf.ContextHead)
+	if body == "" || onlyHTMLComments(body) {
+		b.WriteString("_No entries yet._\n\n")
+		return
+	}
+	b.WriteString(body)
+	b.WriteString("\n\n")
+}
+
+// stripLeadingTitle drops the first `# ...` line if the file starts with
+// one — the section heading printed by BuildContext already covers it.
+func stripLeadingTitle(content string) string {
+	trimmed := strings.TrimLeft(content, "\n")
+	if !strings.HasPrefix(trimmed, "# ") {
+		return content
+	}
+	if idx := strings.Index(trimmed, "\n"); idx >= 0 {
+		return trimmed[idx+1:]
+	}
+	return ""
+}
+
+// onlyHTMLComments returns true if the (trimmed) content has no real
+// prose — only the `<!-- ... -->` placeholder we wrote at init time.
+func onlyHTMLComments(content string) bool {
+	stripped := content
+	for {
+		start := strings.Index(stripped, "<!--")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(stripped[start:], "-->")
+		if end < 0 {
+			break
+		}
+		stripped = stripped[:start] + stripped[start+end+3:]
+	}
+	return strings.TrimSpace(stripped) == ""
+}
+
+func writeWarningsSection(b *strings.Builder, scan *Scan) {
+	b.WriteString("## Warnings\n\n")
+	if scan == nil || len(scan.Warnings) == 0 {
+		b.WriteString("_None._\n")
+		return
+	}
+	for _, w := range scan.Warnings {
+		fmt.Fprintf(b, "- %s\n", w)
+	}
+}

--- a/cli/internal/brain/context_test.go
+++ b/cli/internal/brain/context_test.go
@@ -1,0 +1,131 @@
+package brain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildContext_FullDocument(t *testing.T) {
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureMemoryFiles(p); err != nil {
+		t.Fatal(err)
+	}
+	// Write a real entry into decisions.md to verify the empty-template
+	// detector doesn't swallow real content.
+	mustWrite(t, filepath.Join(p.MemoriesDir, "decisions.md"),
+		"# Decisions\n\n## Use Koin as DI\n\n- status: active\n")
+
+	cfg := Config{
+		Version:     ConfigVersion,
+		ProjectName: "demo-kmp",
+		ProjectType: ProjectTypeKMP,
+		Platforms:   []string{"android", "ios", "shared"},
+		Rules:       []string{"Prioritize clean architecture"},
+	}
+	scan := &Scan{
+		Version:      ScanVersion,
+		ProjectType:  ProjectTypeKMP,
+		Platforms:    []string{"android", "ios"},
+		BuildSystems: []string{"gradle"},
+		UI:           []string{"compose_multiplatform"},
+		DI:           []string{"koin"},
+		Integrations: []string{"firebase"},
+		Warnings:     []string{"archivo sensible detectado: .env (no leído)"},
+	}
+
+	md := BuildContext(cfg, scan, p)
+
+	for _, want := range []string{
+		"# MobiAI Brain Context",
+		"Project: demo-kmp",
+		"Type: Kotlin Multiplatform",
+		"Platforms: android, ios, shared",
+		"## Detected Stack",
+		"- UI: compose_multiplatform",
+		"- DI: koin",
+		"- Integrations: firebase",
+		"## Project Rules",
+		"- Prioritize clean architecture",
+		"## Architecture Decisions",
+		"## Use Koin as DI",
+		"## Known Bugfixes",
+		"_No entries yet._",
+		"## Testing Patterns",
+		"## Integrations",
+		"## Release Notes",
+		"## Warnings",
+		"archivo sensible detectado: .env",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("BuildContext output missing %q\n--- output ---\n%s", want, md)
+		}
+	}
+}
+
+func TestBuildContext_NoScanYet(t *testing.T) {
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureMemoryFiles(p); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{
+		Version:     ConfigVersion,
+		ProjectName: "fresh",
+		ProjectType: ProjectTypeUnknown,
+	}
+	md := BuildContext(cfg, nil, p)
+
+	for _, want := range []string{
+		"Project: fresh",
+		"Type: Unknown",
+		"## Detected Stack",
+		"_No scan yet. Run `mobiai brain scan`._",
+		"## Warnings",
+		"_None._",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("missing %q in output:\n%s", want, md)
+		}
+	}
+}
+
+func TestEnsureMemoryFiles_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	created, err := EnsureMemoryFiles(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(created) != len(MemoryFiles) {
+		t.Errorf("first run created %d files, want %d", len(created), len(MemoryFiles))
+	}
+
+	// Mutate one file: re-running must not overwrite it.
+	target := filepath.Join(p.MemoriesDir, "decisions.md")
+	if err := os.WriteFile(target, []byte("# user content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	created2, err := EnsureMemoryFiles(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(created2) != 0 {
+		t.Errorf("second run created %d files, want 0", len(created2))
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "# user content" {
+		t.Errorf("decisions.md was overwritten: %q", string(got))
+	}
+}

--- a/cli/internal/brain/detect_android_platform.go
+++ b/cli/internal/brain/detect_android_platform.go
@@ -1,0 +1,51 @@
+package brain
+
+import "strings"
+
+// detectAndroid registers Android signals in s. Triggered by:
+//   - any AndroidManifest.xml in the tree
+//   - build.gradle{,.kts} containing the Android plugin id
+func detectAndroid(idx *scanIndex, s *Scan, types, platforms map[string]struct{}) {
+	hasManifest := false
+	for path, isDir := range idx.allPaths {
+		if isDir {
+			continue
+		}
+		if strings.HasSuffix(path, "/AndroidManifest.xml") || path == "AndroidManifest.xml" {
+			hasManifest = true
+			s.DetectedFiles["android_manifest"] = path
+			break
+		}
+	}
+
+	hasAndroidPlugin := false
+	for _, needle := range []string{
+		"com.android.application",
+		"com.android.library",
+		"org.jetbrains.kotlin.android",
+	} {
+		if idx.containsAny(needle) {
+			hasAndroidPlugin = true
+			break
+		}
+	}
+
+	if hasManifest || hasAndroidPlugin {
+		types[ProjectTypeAndroid] = struct{}{}
+		platforms[PlatformAndroid] = struct{}{}
+		s.BuildSystems = append(s.BuildSystems, "gradle")
+
+		// Record the most authoritative gradle file we have.
+		for _, candidate := range []string{
+			"settings.gradle.kts",
+			"settings.gradle",
+			"build.gradle.kts",
+			"build.gradle",
+		} {
+			if _, ok := idx.files[candidate]; ok {
+				s.DetectedFiles["settings_gradle"] = candidate
+				break
+			}
+		}
+	}
+}

--- a/cli/internal/brain/detect_deps.go
+++ b/cli/internal/brain/detect_deps.go
@@ -1,0 +1,128 @@
+package brain
+
+import "strings"
+
+// techMatcher maps a label to a bucket on Scan, with the needles that
+// trigger the match. Needles are matched case-insensitively against the
+// content of every interesting file in the index. Order doesn't matter;
+// dedupAllBuckets normalizes the final lists.
+type techMatcher struct {
+	Label   string
+	Bucket  string // "ui" | "di" | "network" | "persistence" | "serialization" | "testing" | "integrations" | "build_systems"
+	Needles []string
+}
+
+var techMatchers = []techMatcher{
+	// UI
+	{"compose_multiplatform", "ui", []string{"org.jetbrains.compose"}},
+	{"compose", "ui", []string{"androidx.compose"}},
+	{"swiftui", "ui", []string{"import SwiftUI"}},
+	{"uikit", "ui", []string{"import UIKit"}},
+	{"coil", "ui", []string{"io.coil-kt"}},
+	{"glide", "ui", []string{"com.github.bumptech.glide"}},
+
+	// DI
+	{"koin", "di", []string{"io.insert-koin", "org.koin"}},
+	{"hilt", "di", []string{"com.google.dagger.hilt", "dagger.hilt.android"}},
+	{"dagger", "di", []string{"com.google.dagger:dagger"}},
+
+	// Network
+	{"ktor", "network", []string{"io.ktor"}},
+	{"retrofit", "network", []string{"com.squareup.retrofit2"}},
+	{"okhttp", "network", []string{"com.squareup.okhttp3"}},
+
+	// Persistence
+	{"room", "persistence", []string{"androidx.room"}},
+	{"datastore", "persistence", []string{"androidx.datastore"}},
+	{"sqldelight", "persistence", []string{"app.cash.sqldelight"}},
+	{"realm", "persistence", []string{"io.realm"}},
+
+	// Serialization
+	{"kotlinx.serialization", "serialization", []string{"kotlinx.serialization", "plugin.serialization"}},
+	{"gson", "serialization", []string{"com.google.code.gson"}},
+	{"moshi", "serialization", []string{"com.squareup.moshi"}},
+
+	// Testing
+	{"junit", "testing", []string{"junit:junit", "org.junit"}},
+	{"mockk", "testing", []string{"io.mockk"}},
+	{"mockito", "testing", []string{"org.mockito"}},
+	{"turbine", "testing", []string{"app.cash.turbine"}},
+	{"espresso", "testing", []string{"androidx.test.espresso"}},
+
+	// Integrations
+	{"firebase", "integrations", []string{"com.google.firebase", "google-services", "Firebase/Core"}},
+}
+
+// detectDeps fans out the techMatchers across the index and bucketizes hits.
+// Some signals (CI/CD, sensitive files) come from path-level checks rather
+// than content matching — those live in dedicated helpers below.
+func detectDeps(idx *scanIndex, s *Scan) {
+	for _, m := range techMatchers {
+		for _, needle := range m.Needles {
+			if !idx.containsAny(needle) {
+				continue
+			}
+			appendBucket(s, m.Bucket, m.Label)
+			break
+		}
+	}
+	detectCICD(idx, s)
+	detectSensitiveFiles(idx, s)
+}
+
+func appendBucket(s *Scan, bucket, label string) {
+	switch bucket {
+	case "ui":
+		s.UI = append(s.UI, label)
+	case "di":
+		s.DI = append(s.DI, label)
+	case "network":
+		s.Network = append(s.Network, label)
+	case "persistence":
+		s.Persistence = append(s.Persistence, label)
+	case "serialization":
+		s.Serialization = append(s.Serialization, label)
+	case "testing":
+		s.Testing = append(s.Testing, label)
+	case "integrations":
+		s.Integrations = append(s.Integrations, label)
+	case "build_systems":
+		s.BuildSystems = append(s.BuildSystems, label)
+	}
+}
+
+// detectCICD looks for well-known CI files/dirs by path, not content,
+// so we don't have to load every YAML in the repo into memory.
+func detectCICD(idx *scanIndex, s *Scan) {
+	for path, isDir := range idx.allPaths {
+		switch {
+		case isDir && (path == ".github/workflows" || strings.HasSuffix(path, "/.github/workflows")):
+			s.CICD = append(s.CICD, "github_actions")
+		case !isDir && (path == "bitrise.yml" || strings.HasSuffix(path, "/bitrise.yml")):
+			s.CICD = append(s.CICD, "bitrise")
+		case !isDir && (path == "codemagic.yaml" || strings.HasSuffix(path, "/codemagic.yaml")):
+			s.CICD = append(s.CICD, "codemagic")
+		case !isDir && (path == "fastlane/Fastfile" || strings.HasSuffix(path, "/fastlane/Fastfile")):
+			s.CICD = append(s.CICD, "fastlane")
+		}
+	}
+}
+
+// detectSensitiveFiles records the existence of files that often carry
+// secrets, but never reads their content. The user (and downstream
+// agents) get a heads-up via warnings without leaking bytes anywhere.
+func detectSensitiveFiles(idx *scanIndex, s *Scan) {
+	for path, isDir := range idx.allPaths {
+		if isDir {
+			continue
+		}
+		switch {
+		case path == ".env" || strings.HasSuffix(path, "/.env"):
+			s.Warnings = append(s.Warnings, "archivo sensible detectado: "+path+" (no leído)")
+		case strings.HasSuffix(path, "/GoogleService-Info.plist") || path == "GoogleService-Info.plist":
+			s.Warnings = append(s.Warnings, "archivo sensible detectado: "+path+" (no leído)")
+		case strings.HasSuffix(path, "/google-services.json") || path == "google-services.json":
+			s.Warnings = append(s.Warnings, "archivo sensible detectado: "+path+" (no leído)")
+		}
+	}
+}

--- a/cli/internal/brain/detect_flutter_platform.go
+++ b/cli/internal/brain/detect_flutter_platform.go
@@ -1,0 +1,28 @@
+package brain
+
+import "strings"
+
+// detectFlutter registers Flutter signals. Triggered by pubspec.yaml
+// containing a `flutter:` key (Dart packages without Flutter use the same
+// file but lack that section).
+func detectFlutter(idx *scanIndex, s *Scan, types, platforms map[string]struct{}) {
+	pubspec, ok := idx.files["pubspec.yaml"]
+	if !ok {
+		return
+	}
+	content := string(pubspec)
+	if !strings.Contains(content, "\nflutter:") && !strings.HasPrefix(content, "flutter:") {
+		// pure Dart package — not Flutter.
+		return
+	}
+	types[ProjectTypeFlutter] = struct{}{}
+	s.DetectedFiles["pubspec_yaml"] = "pubspec.yaml"
+
+	if idx.hasDir("android") {
+		platforms[PlatformAndroid] = struct{}{}
+	}
+	if idx.hasDir("ios") {
+		platforms[PlatformIOS] = struct{}{}
+	}
+	platforms[PlatformShared] = struct{}{}
+}

--- a/cli/internal/brain/detect_ios_platform.go
+++ b/cli/internal/brain/detect_ios_platform.go
@@ -1,0 +1,51 @@
+package brain
+
+import "strings"
+
+// detectIOS registers iOS signals. Triggered by any of:
+//   - Podfile
+//   - Package.swift
+//   - *.xcodeproj or *.xcworkspace directory
+//   - Info.plist file (rare on its own; mostly catches SDK-only repos)
+func detectIOS(idx *scanIndex, s *Scan, types, platforms map[string]struct{}) {
+	hit := false
+
+	if _, ok := idx.files["Podfile"]; ok {
+		hit = true
+		s.DetectedFiles["podfile"] = "Podfile"
+		s.BuildSystems = append(s.BuildSystems, "cocoapods")
+	}
+	for path := range idx.allPaths {
+		if strings.HasSuffix(path, "/Podfile") {
+			hit = true
+			if _, set := s.DetectedFiles["podfile"]; !set {
+				s.DetectedFiles["podfile"] = path
+			}
+			s.BuildSystems = append(s.BuildSystems, "cocoapods")
+			break
+		}
+	}
+	if _, ok := idx.files["Package.swift"]; ok {
+		hit = true
+		s.DetectedFiles["package_swift"] = "Package.swift"
+		s.BuildSystems = append(s.BuildSystems, "spm")
+	}
+	for path, isDir := range idx.allPaths {
+		if !isDir {
+			continue
+		}
+		if strings.HasSuffix(path, ".xcodeproj") {
+			hit = true
+			s.DetectedFiles["xcodeproj"] = path
+		}
+		if strings.HasSuffix(path, ".xcworkspace") {
+			hit = true
+			s.DetectedFiles["xcworkspace"] = path
+		}
+	}
+	if !hit {
+		return
+	}
+	types[ProjectTypeIOS] = struct{}{}
+	platforms[PlatformIOS] = struct{}{}
+}

--- a/cli/internal/brain/detect_ios_platform.go
+++ b/cli/internal/brain/detect_ios_platform.go
@@ -6,7 +6,10 @@ import "strings"
 //   - Podfile
 //   - Package.swift
 //   - *.xcodeproj or *.xcworkspace directory
-//   - Info.plist file (rare on its own; mostly catches SDK-only repos)
+//
+// Info.plist on its own is intentionally NOT a trigger: it appears in
+// many non-iOS repos (vendored frameworks, code-signing artefacts) and
+// would cause false positives.
 func detectIOS(idx *scanIndex, s *Scan, types, platforms map[string]struct{}) {
 	hit := false
 

--- a/cli/internal/brain/detect_kmp_platform.go
+++ b/cli/internal/brain/detect_kmp_platform.go
@@ -1,0 +1,55 @@
+package brain
+
+import "strings"
+
+// detectKMP registers Kotlin Multiplatform signals. Triggered when any
+// Gradle file declares the multiplatform plugin OR a commonMain source
+// set is present. KMP usually implies both Android and iOS targets, but
+// we only add platforms we can directly observe (so single-target KMP
+// libs scan cleanly too).
+func detectKMP(idx *scanIndex, s *Scan, types, platforms map[string]struct{}) {
+	pluginNeedles := []string{
+		"kotlin(\"multiplatform\")",
+		"kotlin('multiplatform')",
+		"org.jetbrains.kotlin.multiplatform",
+	}
+	hasPlugin := false
+	for _, n := range pluginNeedles {
+		if idx.containsAny(n) {
+			hasPlugin = true
+			break
+		}
+	}
+	hasCommonMain := false
+	for path, isDir := range idx.allPaths {
+		if !isDir {
+			continue
+		}
+		if strings.HasSuffix(path, "/commonMain") || path == "commonMain" {
+			hasCommonMain = true
+			break
+		}
+	}
+	if !hasPlugin && !hasCommonMain {
+		return
+	}
+
+	types[ProjectTypeKMP] = struct{}{}
+
+	// Walk the dir set once to attribute Android/iOS targets.
+	for path, isDir := range idx.allPaths {
+		if !isDir {
+			continue
+		}
+		if strings.HasSuffix(path, "/androidMain") || path == "androidMain" {
+			platforms[PlatformAndroid] = struct{}{}
+		}
+		if strings.HasSuffix(path, "/iosMain") || path == "iosMain" ||
+			strings.HasSuffix(path, "/iosArm64Main") || strings.HasSuffix(path, "/iosX64Main") ||
+			strings.HasSuffix(path, "/iosSimulatorArm64Main") {
+			platforms[PlatformIOS] = struct{}{}
+		}
+	}
+	platforms[PlatformShared] = struct{}{}
+	s.BuildSystems = append(s.BuildSystems, "gradle")
+}

--- a/cli/internal/brain/detect_reactnative_platform.go
+++ b/cli/internal/brain/detect_reactnative_platform.go
@@ -1,0 +1,32 @@
+package brain
+
+import "strings"
+
+// detectReactNative registers RN signals. Triggered by package.json with
+// a "react-native" dependency (devDependencies counts too) AND either a
+// metro.config.js or an android/ + ios/ pair.
+func detectReactNative(idx *scanIndex, s *Scan, types, platforms map[string]struct{}) {
+	pkg, ok := idx.files["package.json"]
+	if !ok {
+		return
+	}
+	if !strings.Contains(string(pkg), "\"react-native\"") {
+		return
+	}
+	if _, ok := idx.files["metro.config.js"]; !ok && !(idx.hasDir("android") && idx.hasDir("ios")) {
+		return
+	}
+	types[ProjectTypeReactNative] = struct{}{}
+	platforms[PlatformShared] = struct{}{}
+	if idx.hasDir("android") {
+		platforms[PlatformAndroid] = struct{}{}
+	}
+	if idx.hasDir("ios") {
+		platforms[PlatformIOS] = struct{}{}
+	}
+	s.DetectedFiles["package_json"] = "package.json"
+	if _, ok := idx.files["metro.config.js"]; ok {
+		s.DetectedFiles["metro_config"] = "metro.config.js"
+	}
+	s.BuildSystems = append(s.BuildSystems, "npm")
+}

--- a/cli/internal/brain/memory.go
+++ b/cli/internal/brain/memory.go
@@ -1,0 +1,127 @@
+package brain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MemoryFile describes one Markdown memory file under <brain>/memories/.
+// Order in MemoryFiles is the order used in the generated context.
+type MemoryFile struct {
+	Name        string // filename, e.g. "decisions.md"
+	Title       string // human-readable section title
+	ContextHead string // section heading printed by `brain context`
+	Template    string // initial content written by `brain init`
+}
+
+// MemoryFiles is the canonical list of memory categories. Phase 1 ships
+// 5 categories; future `brain save` subcommands will append to them.
+var MemoryFiles = []MemoryFile{
+	{
+		Name:        "decisions.md",
+		Title:       "Architecture Decisions",
+		ContextHead: "## Architecture Decisions",
+		Template:    decisionsTemplate,
+	},
+	{
+		Name:        "bugfixes.md",
+		Title:       "Known Bugfixes",
+		ContextHead: "## Known Bugfixes",
+		Template:    bugfixesTemplate,
+	},
+	{
+		Name:        "testing.md",
+		Title:       "Testing Patterns",
+		ContextHead: "## Testing Patterns",
+		Template:    testingTemplate,
+	},
+	{
+		Name:        "integrations.md",
+		Title:       "Integrations",
+		ContextHead: "## Integrations",
+		Template:    integrationsTemplate,
+	},
+	{
+		Name:        "releases.md",
+		Title:       "Release Notes",
+		ContextHead: "## Release Notes",
+		Template:    releasesTemplate,
+	},
+}
+
+// EnsureMemoryFiles writes any missing memory file with its template.
+// Existing files are left untouched (idempotent — `brain init` may run
+// many times). Returns the list of files actually created.
+func EnsureMemoryFiles(p BrainPaths) ([]string, error) {
+	if err := os.MkdirAll(p.MemoriesDir, 0o755); err != nil {
+		return nil, fmt.Errorf("crear %s: %w", p.MemoriesDir, err)
+	}
+	var created []string
+	for _, mf := range MemoryFiles {
+		path := filepath.Join(p.MemoriesDir, mf.Name)
+		if _, err := os.Stat(path); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return created, fmt.Errorf("stat %s: %w", path, err)
+		}
+		if err := os.WriteFile(path, []byte(mf.Template), 0o644); err != nil {
+			return created, fmt.Errorf("escribir %s: %w", path, err)
+		}
+		created = append(created, mf.Name)
+	}
+	return created, nil
+}
+
+// readMemory returns the file's content, or an empty string if missing.
+func readMemory(p BrainPaths, name string) string {
+	data, err := os.ReadFile(filepath.Join(p.MemoriesDir, name))
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+const decisionsTemplate = `# Decisions
+
+<!--
+Architecture decisions specific to this project.
+Append entries with: mobiai brain save decision (coming in Phase 2).
+Each entry should record: title, status (active|deprecated), platform,
+area, date, decision, reason, files.
+-->
+`
+
+const bugfixesTemplate = `# Bugfixes
+
+<!--
+Bugfixes and workarounds worth remembering for this project.
+Append entries with: mobiai brain save bugfix (coming in Phase 2).
+Mark temporary workarounds as status: temporary so the agent does not
+treat them as permanent decisions.
+-->
+`
+
+const testingTemplate = `# Testing Patterns
+
+<!--
+Reusable testing patterns discovered for this project.
+Append entries with: mobiai brain save testing (coming in Phase 2).
+Include the problem, the pattern that solved it and a minimal example.
+-->
+`
+
+const integrationsTemplate = `# Integrations
+
+<!--
+Notes on third-party integrations (Firebase, analytics, push, payments,
+etc.) and their project-specific configuration quirks.
+-->
+`
+
+const releasesTemplate = `# Releases
+
+<!--
+Release notes, checklists and lessons learned during shipping.
+-->
+`

--- a/cli/internal/brain/paths.go
+++ b/cli/internal/brain/paths.go
@@ -1,0 +1,182 @@
+// Package brain implements MobiAI Brain — per-project memory for mobile
+// agents. Each project gets its own .mobiai/brain/ directory with config,
+// stack scan and Markdown memories. This package is pure (no cobra deps)
+// so it can be reused from MCP tools or other commands later.
+package brain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// BrainPaths describes the on-disk layout of a project-local brain.
+// The global tool state lives in "~/.mobiai/" (managed by the state
+// package); a brain lives inside the *project*, never in $HOME.
+type BrainPaths struct {
+	Root        string // absolute project root
+	Dir         string // <root>/.mobiai/brain
+	ConfigFile  string // <root>/.mobiai/brain/config.json
+	ScanFile    string // <root>/.mobiai/brain/scan.json
+	MemoriesDir string // <root>/.mobiai/brain/memories
+}
+
+// NewBrainPaths returns the canonical brain layout for projectRoot.
+// It does not touch the filesystem.
+func NewBrainPaths(projectRoot string) BrainPaths {
+	abs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		abs = projectRoot
+	}
+	dir := filepath.Join(abs, ".mobiai", "brain")
+	return BrainPaths{
+		Root:        abs,
+		Dir:         dir,
+		ConfigFile:  filepath.Join(dir, "config.json"),
+		ScanFile:    filepath.Join(dir, "scan.json"),
+		MemoriesDir: filepath.Join(dir, "memories"),
+	}
+}
+
+// EnsureDirs creates Dir and MemoriesDir if they do not exist.
+func (p BrainPaths) EnsureDirs() error {
+	if err := os.MkdirAll(p.MemoriesDir, 0o755); err != nil {
+		return fmt.Errorf("crear %s: %w", p.MemoriesDir, err)
+	}
+	return nil
+}
+
+// Exists reports whether a brain has already been initialized at this root
+// (i.e. config.json exists).
+func (p BrainPaths) Exists() bool {
+	_, err := os.Stat(p.ConfigFile)
+	return err == nil
+}
+
+// RootSource describes how the project root was located. Useful for
+// debugging surprising cwd → root resolutions.
+type RootSource string
+
+const (
+	RootSourceBrain   RootSource = "brain"   // existing .mobiai/brain/config.json found
+	RootSourceGit     RootSource = "git"     // .git directory
+	RootSourceGradle  RootSource = "gradle"  // settings.gradle(.kts)
+	RootSourcePubspec RootSource = "pubspec" // pubspec.yaml (Flutter)
+	RootSourceSwift   RootSource = "swift"   // Package.swift
+	RootSourceXcode   RootSource = "xcode"   // *.xcworkspace or *.xcodeproj
+	RootSourcePodfile RootSource = "podfile" // Podfile
+	RootSourceRN      RootSource = "rn"      // package.json with react-native dep
+	RootSourceCwd     RootSource = "cwd"     // fallback: nothing matched
+)
+
+// RootInfo is the result of FindProjectRoot.
+type RootInfo struct {
+	Path    string
+	Source  RootSource
+	Warning string // populated when falling back to cwd
+}
+
+// FindProjectRoot walks up from start looking for a project marker.
+// Order of priority (most specific first):
+//
+//  1. .mobiai/brain/config.json — an already-initialized brain wins.
+//  2. .git directory.
+//  3. settings.gradle(.kts) — Android / KMP.
+//  4. pubspec.yaml — Flutter.
+//  5. Package.swift — iOS SPM.
+//  6. *.xcworkspace or *.xcodeproj — iOS Xcode.
+//  7. Podfile — iOS CocoaPods.
+//  8. package.json with "react-native" dep — RN.
+//
+// If nothing matches, returns start (absolutized) with a warning.
+func FindProjectRoot(start string) (RootInfo, error) {
+	if start == "" {
+		return RootInfo{}, fmt.Errorf("ruta de inicio vacía")
+	}
+	abs, err := filepath.Abs(start)
+	if err != nil {
+		return RootInfo{}, fmt.Errorf("absolutizar %s: %w", start, err)
+	}
+	dir := abs
+	for {
+		if src, ok := detectMarker(dir); ok {
+			return RootInfo{Path: dir, Source: src}, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return RootInfo{
+		Path:    abs,
+		Source:  RootSourceCwd,
+		Warning: "no encontré marcador de proyecto, uso el directorio actual",
+	}, nil
+}
+
+// detectMarker checks dir for any known marker and returns the matching
+// source. Order matters — most specific first.
+func detectMarker(dir string) (RootSource, bool) {
+	if isFile(filepath.Join(dir, ".mobiai", "brain", "config.json")) {
+		return RootSourceBrain, true
+	}
+	if isDir(filepath.Join(dir, ".git")) || isFile(filepath.Join(dir, ".git")) {
+		// .git can be a file inside worktrees; either is fine.
+		return RootSourceGit, true
+	}
+	if isFile(filepath.Join(dir, "settings.gradle.kts")) || isFile(filepath.Join(dir, "settings.gradle")) {
+		return RootSourceGradle, true
+	}
+	if isFile(filepath.Join(dir, "pubspec.yaml")) {
+		return RootSourcePubspec, true
+	}
+	if isFile(filepath.Join(dir, "Package.swift")) {
+		return RootSourceSwift, true
+	}
+	if hasGlob(dir, ".xcworkspace") || hasGlob(dir, ".xcodeproj") {
+		return RootSourceXcode, true
+	}
+	if isFile(filepath.Join(dir, "Podfile")) {
+		return RootSourcePodfile, true
+	}
+	if isFile(filepath.Join(dir, "package.json")) {
+		if pkg, err := os.ReadFile(filepath.Join(dir, "package.json")); err == nil {
+			if strings.Contains(string(pkg), "\"react-native\"") {
+				return RootSourceRN, true
+			}
+		}
+	}
+	return "", false
+}
+
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// hasGlob returns true if dir contains an entry whose name ends with suffix.
+func hasGlob(dir, suffix string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/brain/paths_test.go
+++ b/cli/internal/brain/paths_test.go
@@ -1,0 +1,189 @@
+package brain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewBrainPaths_Layout(t *testing.T) {
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	if p.Root != tmp {
+		t.Errorf("Root = %q, want %q", p.Root, tmp)
+	}
+	if got, want := p.Dir, filepath.Join(tmp, ".mobiai", "brain"); got != want {
+		t.Errorf("Dir = %q, want %q", got, want)
+	}
+	if got, want := p.ConfigFile, filepath.Join(tmp, ".mobiai", "brain", "config.json"); got != want {
+		t.Errorf("ConfigFile = %q, want %q", got, want)
+	}
+	if got, want := p.ScanFile, filepath.Join(tmp, ".mobiai", "brain", "scan.json"); got != want {
+		t.Errorf("ScanFile = %q, want %q", got, want)
+	}
+	if got, want := p.MemoriesDir, filepath.Join(tmp, ".mobiai", "brain", "memories"); got != want {
+		t.Errorf("MemoriesDir = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureDirs_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	// Second call must not error.
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(p.MemoriesDir); err != nil {
+		t.Errorf("memories dir not created: %v", err)
+	}
+}
+
+func TestExists(t *testing.T) {
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	if p.Exists() {
+		t.Fatal("Exists should be false on a fresh dir")
+	}
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.ConfigFile, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !p.Exists() {
+		t.Error("Exists should be true after writing config.json")
+	}
+}
+
+func TestFindProjectRoot(t *testing.T) {
+	type setup func(t *testing.T, root string)
+	cases := []struct {
+		name    string
+		build   setup
+		startIn string // relative path inside root where we start the search
+		want    RootSource
+	}{
+		{
+			name: "existing brain wins over git",
+			build: func(t *testing.T, root string) {
+				mustMkdir(t, filepath.Join(root, ".git"))
+				mustMkdir(t, filepath.Join(root, ".mobiai", "brain"))
+				mustWrite(t, filepath.Join(root, ".mobiai", "brain", "config.json"), "{}")
+			},
+			startIn: ".",
+			want:    RootSourceBrain,
+		},
+		{
+			name: "git marker",
+			build: func(t *testing.T, root string) {
+				mustMkdir(t, filepath.Join(root, ".git"))
+			},
+			startIn: ".",
+			want:    RootSourceGit,
+		},
+		{
+			name: "settings.gradle.kts (Android/KMP)",
+			build: func(t *testing.T, root string) {
+				mustWrite(t, filepath.Join(root, "settings.gradle.kts"), "")
+			},
+			startIn: ".",
+			want:    RootSourceGradle,
+		},
+		{
+			name: "pubspec.yaml (Flutter)",
+			build: func(t *testing.T, root string) {
+				mustWrite(t, filepath.Join(root, "pubspec.yaml"), "name: x\n")
+			},
+			startIn: ".",
+			want:    RootSourcePubspec,
+		},
+		{
+			name: "Package.swift (iOS SPM)",
+			build: func(t *testing.T, root string) {
+				mustWrite(t, filepath.Join(root, "Package.swift"), "")
+			},
+			startIn: ".",
+			want:    RootSourceSwift,
+		},
+		{
+			name: "xcworkspace dir (iOS Xcode)",
+			build: func(t *testing.T, root string) {
+				mustMkdir(t, filepath.Join(root, "App.xcworkspace"))
+			},
+			startIn: ".",
+			want:    RootSourceXcode,
+		},
+		{
+			name: "Podfile only",
+			build: func(t *testing.T, root string) {
+				mustWrite(t, filepath.Join(root, "Podfile"), "")
+			},
+			startIn: ".",
+			want:    RootSourcePodfile,
+		},
+		{
+			name: "package.json with react-native",
+			build: func(t *testing.T, root string) {
+				mustWrite(t, filepath.Join(root, "package.json"), `{"dependencies": {"react-native": "0.74.0"}}`)
+			},
+			startIn: ".",
+			want:    RootSourceRN,
+		},
+		{
+			name: "package.json without react-native is not enough",
+			build: func(t *testing.T, root string) {
+				mustWrite(t, filepath.Join(root, "package.json"), `{"dependencies": {"react": "18"}}`)
+			},
+			startIn: ".",
+			want:    RootSourceCwd,
+		},
+		{
+			name: "walks up from nested dir",
+			build: func(t *testing.T, root string) {
+				mustMkdir(t, filepath.Join(root, ".git"))
+				mustMkdir(t, filepath.Join(root, "a", "b", "c"))
+			},
+			startIn: filepath.Join("a", "b", "c"),
+			want:    RootSourceGit,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			tc.build(t, root)
+			start := filepath.Join(root, tc.startIn)
+			info, err := FindProjectRoot(start)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Source != tc.want {
+				t.Errorf("Source = %q, want %q (path=%q warning=%q)",
+					info.Source, tc.want, info.Path, info.Warning)
+			}
+			if tc.want == RootSourceCwd && info.Warning == "" {
+				t.Error("expected warning when falling back to cwd")
+			}
+		})
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cli/internal/brain/save.go
+++ b/cli/internal/brain/save.go
@@ -1,0 +1,221 @@
+package brain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// SaveType identifies the memory category an entry targets. The set is
+// closed: each value maps to a fixed memories/<file>.md and a default
+// fully-qualified type label.
+type SaveType string
+
+const (
+	SaveTypeDecision SaveType = "decision"
+	SaveTypeBugfix   SaveType = "bugfix"
+	SaveTypeTesting  SaveType = "testing"
+)
+
+// memoryFileFor returns the basename inside memories/ for a SaveType.
+func (t SaveType) memoryFileFor() (string, error) {
+	switch t {
+	case SaveTypeDecision:
+		return "decisions.md", nil
+	case SaveTypeBugfix:
+		return "bugfixes.md", nil
+	case SaveTypeTesting:
+		return "testing.md", nil
+	default:
+		return "", fmt.Errorf("save type desconocido: %q (esperado: decision|bugfix|testing)", t)
+	}
+}
+
+// fullTypeLabel returns the type: <label> field for the rendered entry.
+// `bugfix` flips between `platform_workaround` and `bug_fix` based on
+// status — that's how the spec disambiguates a real fix from a temporary
+// hack while sharing the same .md file.
+func (t SaveType) fullTypeLabel(status string) string {
+	switch t {
+	case SaveTypeDecision:
+		return "architecture_decision"
+	case SaveTypeBugfix:
+		if strings.EqualFold(status, "temporary") {
+			return "platform_workaround"
+		}
+		return "bug_fix"
+	case SaveTypeTesting:
+		return "testing_pattern"
+	}
+	return string(t)
+}
+
+// Status values accepted for a SaveEntry.
+const (
+	StatusActive     = "active"
+	StatusTemporary  = "temporary"
+	StatusDeprecated = "deprecated"
+)
+
+// validStatuses lists every allowed status value.
+var validStatuses = map[string]struct{}{
+	StatusActive:     {},
+	StatusTemporary:  {},
+	StatusDeprecated: {},
+}
+
+// SaveEntry is a structured memory append. The CLI builds it from flags
+// (and stdin for Body); save_test.go drives it directly.
+type SaveEntry struct {
+	Type        SaveType
+	Title       string
+	Platform    string   // optional
+	Area        string   // optional
+	Status      string   // active|temporary|deprecated, defaults to active
+	ReviewAfter string   // optional, ISO date — meaningful for temporary entries
+	Body        string   // free-form Markdown (may include H3 subheadings)
+	Files       []string // optional list of repo-relative file paths
+	now         func() time.Time
+}
+
+// Validate enforces required fields and value domains. Returns a
+// human-readable error in Spanish (matching CLI tone) on first failure.
+func (e *SaveEntry) Validate() error {
+	if e.Type == "" {
+		return fmt.Errorf("type es requerido")
+	}
+	if _, err := e.Type.memoryFileFor(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(e.Title) == "" {
+		return fmt.Errorf("--title es requerido")
+	}
+	if e.Status == "" {
+		e.Status = StatusActive
+	}
+	if _, ok := validStatuses[e.Status]; !ok {
+		return fmt.Errorf("--status %q inválido (esperado: active|temporary|deprecated)", e.Status)
+	}
+	if e.ReviewAfter != "" {
+		if _, err := time.Parse("2006-01-02", e.ReviewAfter); err != nil {
+			return fmt.Errorf("--review-after debe ser YYYY-MM-DD: %w", err)
+		}
+	}
+	return nil
+}
+
+// AppendEntry validates the entry, ensures the brain exists at p, and
+// appends a Markdown section to the relevant memories/<file>.md. Returns
+// the generated id (slug + timestamp) so callers can echo it.
+func AppendEntry(p BrainPaths, e *SaveEntry) (string, error) {
+	if !p.Exists() {
+		return "", fmt.Errorf("brain no inicializado en %s — corré `mobiai brain init` primero", p.Root)
+	}
+	if err := e.Validate(); err != nil {
+		return "", err
+	}
+	if e.now == nil {
+		e.now = timeNow
+	}
+	id := makeID(e.Title, e.now())
+	rendered := renderEntry(id, e)
+
+	fileBase, _ := e.Type.memoryFileFor()
+	target := filepath.Join(p.MemoriesDir, fileBase)
+	if err := appendToFile(target, rendered); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// makeID builds a stable identifier: <slug-of-title>-<yyyymmdd-hhmmss>.
+// The timestamp keeps two saves with identical titles distinguishable.
+func makeID(title string, now time.Time) string {
+	slug := slugify(title)
+	if slug == "" {
+		slug = "entry"
+	}
+	return fmt.Sprintf("%s-%s", slug, now.UTC().Format("20060102-150405"))
+}
+
+var nonSlugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// slugify lowercases, replaces non-alphanumerics with `-`, trims dashes,
+// and caps length so an oversized title doesn't bloat the id.
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	s = nonSlugRe.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	const maxLen = 60
+	if len(s) > maxLen {
+		s = strings.TrimRight(s[:maxLen], "-")
+	}
+	return s
+}
+
+// renderEntry produces the Markdown section appended to memories/<file>.md.
+// Layout matches the spec: H2 title, metadata bullet list, body as-is,
+// optional Files list. Empty optional fields are omitted entirely (no
+// `platform: ` lines with trailing whitespace).
+func renderEntry(id string, e *SaveEntry) string {
+	var b strings.Builder
+	// Always start with a blank line so we don't fuse with whatever was
+	// previously the last line of the file.
+	b.WriteString("\n## ")
+	b.WriteString(strings.TrimSpace(e.Title))
+	b.WriteString("\n\n")
+
+	fmt.Fprintf(&b, "- id: %s\n", id)
+	fmt.Fprintf(&b, "- type: %s\n", e.Type.fullTypeLabel(e.Status))
+	fmt.Fprintf(&b, "- status: %s\n", e.Status)
+	if e.Platform != "" {
+		fmt.Fprintf(&b, "- platform: %s\n", e.Platform)
+	}
+	if e.Area != "" {
+		fmt.Fprintf(&b, "- area: %s\n", e.Area)
+	}
+	fmt.Fprintf(&b, "- date: %s\n", e.now().UTC().Format("2006-01-02"))
+	if e.ReviewAfter != "" {
+		fmt.Fprintf(&b, "- review_after: %s\n", e.ReviewAfter)
+	}
+
+	body := strings.TrimSpace(e.Body)
+	if body != "" {
+		b.WriteString("\n")
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+
+	if len(e.Files) > 0 {
+		b.WriteString("\n### Files\n")
+		for _, f := range e.Files {
+			f = strings.TrimSpace(f)
+			if f == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+	}
+	return b.String()
+}
+
+// appendToFile opens target in append mode (creating it if needed) and
+// writes content. Used instead of write-temp+rename because Markdown
+// memories are append-only — we never need atomic full-file replacement.
+func appendToFile(target, content string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("crear %s: %w", filepath.Dir(target), err)
+	}
+	f, err := os.OpenFile(target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("abrir %s: %w", target, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		return fmt.Errorf("escribir %s: %w", target, err)
+	}
+	return nil
+}

--- a/cli/internal/brain/save_test.go
+++ b/cli/internal/brain/save_test.go
@@ -1,0 +1,217 @@
+package brain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppendEntry_FailsIfBrainNotInitialized(t *testing.T) {
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	_, err := AppendEntry(p, &SaveEntry{
+		Type:  SaveTypeDecision,
+		Title: "Use Koin",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no inicializado") {
+		t.Fatalf("expected 'no inicializado' error, got: %v", err)
+	}
+}
+
+func TestAppendEntry_DecisionWritesAllFields(t *testing.T) {
+	p := initBrainForTest(t)
+	frozenNow := func() time.Time {
+		return time.Date(2026, 5, 10, 12, 30, 45, 0, time.UTC)
+	}
+	id, err := AppendEntry(p, &SaveEntry{
+		Type:     SaveTypeDecision,
+		Title:    "Use Koin as DI",
+		Platform: "shared",
+		Area:     "dependency_injection",
+		Status:   StatusActive,
+		Body:     "### Decision\nUse Koin.\n\n### Reason\nKMP-friendly.",
+		Files:    []string{"composeApp/src/commonMain/Module.kt"},
+		now:      frozenNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantID := "use-koin-as-di-20260510-123045"
+	if id != wantID {
+		t.Errorf("id = %q, want %q", id, wantID)
+	}
+
+	got, err := os.ReadFile(filepath.Join(p.MemoriesDir, "decisions.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"## Use Koin as DI",
+		"- id: " + wantID,
+		"- type: architecture_decision",
+		"- status: active",
+		"- platform: shared",
+		"- area: dependency_injection",
+		"- date: 2026-05-10",
+		"### Decision",
+		"### Files",
+		"- composeApp/src/commonMain/Module.kt",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestAppendEntry_TemporaryBugfixUsesPlatformWorkaround(t *testing.T) {
+	p := initBrainForTest(t)
+	_, err := AppendEntry(p, &SaveEntry{
+		Type:        SaveTypeBugfix,
+		Title:       "FirebaseAuth iOS module name",
+		Platform:    "ios",
+		Status:      StatusTemporary,
+		ReviewAfter: "2026-09-01",
+		Body:        "### Problem\n...\n\n### Solution\n...",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(p.MemoriesDir, "bugfixes.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "- type: platform_workaround") {
+		t.Errorf("temporary bugfix should map to platform_workaround:\n%s", got)
+	}
+	if !strings.Contains(string(got), "- review_after: 2026-09-01") {
+		t.Errorf("review_after missing:\n%s", got)
+	}
+}
+
+func TestAppendEntry_PermanentBugfixUsesBugFix(t *testing.T) {
+	p := initBrainForTest(t)
+	_, err := AppendEntry(p, &SaveEntry{
+		Type:   SaveTypeBugfix,
+		Title:  "Crash on empty cart",
+		Status: StatusActive,
+		Body:   "fixed null deref",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(p.MemoriesDir, "bugfixes.md"))
+	if !strings.Contains(string(got), "- type: bug_fix") {
+		t.Errorf("active bugfix should map to bug_fix:\n%s", got)
+	}
+}
+
+func TestAppendEntry_TestingDefaultsStatusToActive(t *testing.T) {
+	p := initBrainForTest(t)
+	_, err := AppendEntry(p, &SaveEntry{
+		Type:  SaveTypeTesting,
+		Title: "DataStore clear waits for empty emission",
+		Body:  "use first { ... }",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(p.MemoriesDir, "testing.md"))
+	if !strings.Contains(string(got), "- status: active") {
+		t.Errorf("default status should be active:\n%s", got)
+	}
+	if !strings.Contains(string(got), "- type: testing_pattern") {
+		t.Errorf("testing type missing:\n%s", got)
+	}
+}
+
+func TestAppendEntry_AppendsDoNotOverwrite(t *testing.T) {
+	p := initBrainForTest(t)
+	for _, title := range []string{"First decision", "Second decision"} {
+		if _, err := AppendEntry(p, &SaveEntry{
+			Type:  SaveTypeDecision,
+			Title: title,
+			Body:  "body for " + title,
+			now:   func() time.Time { return time.Now() },
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, _ := os.ReadFile(filepath.Join(p.MemoriesDir, "decisions.md"))
+	for _, want := range []string{"## First decision", "## Second decision"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("missing %q after two saves; file:\n%s", want, got)
+		}
+	}
+}
+
+func TestAppendEntry_RejectsInvalidStatus(t *testing.T) {
+	p := initBrainForTest(t)
+	_, err := AppendEntry(p, &SaveEntry{
+		Type:   SaveTypeDecision,
+		Title:  "x",
+		Status: "wat",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status") {
+		t.Errorf("expected status error, got: %v", err)
+	}
+}
+
+func TestAppendEntry_RejectsBadReviewAfter(t *testing.T) {
+	p := initBrainForTest(t)
+	_, err := AppendEntry(p, &SaveEntry{
+		Type:        SaveTypeBugfix,
+		Title:       "x",
+		Status:      StatusTemporary,
+		ReviewAfter: "tomorrow",
+	})
+	if err == nil || !strings.Contains(err.Error(), "review-after") {
+		t.Errorf("expected review-after error, got: %v", err)
+	}
+}
+
+func TestAppendEntry_RequiresTitle(t *testing.T) {
+	p := initBrainForTest(t)
+	_, err := AppendEntry(p, &SaveEntry{
+		Type:  SaveTypeDecision,
+		Title: "   ",
+	})
+	if err == nil || !strings.Contains(err.Error(), "title") {
+		t.Errorf("expected title error, got: %v", err)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Use Koin as DI":                     "use-koin-as-di",
+		"  Trim Spaces  ":                    "trim-spaces",
+		"FirebaseAuth iOS — module renaming": "firebaseauth-ios-module-renaming",
+		"!!!":                                "",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// initBrainForTest creates a fully initialized brain in a TempDir and
+// returns its paths. Used to avoid the brain-not-initialized guard in
+// tests that exercise append behavior.
+func initBrainForTest(t *testing.T) BrainPaths {
+	t.Helper()
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig(tmp)
+	if err := cfg.Save(p); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureMemoryFiles(p); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}

--- a/cli/internal/brain/scan.go
+++ b/cli/internal/brain/scan.go
@@ -1,0 +1,102 @@
+package brain
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// ScanVersion is the schema version of scan.json.
+const ScanVersion = 1
+
+// Project type constants used in Config and Scan.
+const (
+	ProjectTypeUnknown     = "unknown"
+	ProjectTypeAndroid     = "android"
+	ProjectTypeIOS         = "ios"
+	ProjectTypeKMP         = "kmp"
+	ProjectTypeFlutter     = "flutter"
+	ProjectTypeReactNative = "react_native"
+)
+
+// Platform constants.
+const (
+	PlatformAndroid = "android"
+	PlatformIOS     = "ios"
+	PlatformShared  = "shared"
+)
+
+// Scan is the persisted shape of <brain>/scan.json. Field names match the
+// spec in MobiAI Brain Phase 1.
+type Scan struct {
+	Version       int               `json:"version"`
+	ProjectName   string            `json:"project_name"`
+	ProjectType   string            `json:"project_type"`
+	Platforms     []string          `json:"platforms"`
+	BuildSystems  []string          `json:"build_systems"`
+	UI            []string          `json:"ui"`
+	DI            []string          `json:"di"`
+	Network       []string          `json:"network"`
+	Persistence   []string          `json:"persistence"`
+	Serialization []string          `json:"serialization"`
+	Testing       []string          `json:"testing"`
+	Integrations  []string          `json:"integrations"`
+	CICD          []string          `json:"ci_cd"`
+	DetectedFiles map[string]string `json:"detected_files"`
+	Warnings      []string          `json:"warnings"`
+	CreatedAt     string            `json:"created_at"`
+	UpdatedAt     string            `json:"updated_at"`
+}
+
+// LoadScan reads <brain>/scan.json. Returns (nil, nil) if the file does
+// not exist (a fresh brain that hasn't been scanned yet).
+func LoadScan(p BrainPaths) (*Scan, error) {
+	data, err := os.ReadFile(p.ScanFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read scan.json: %w", err)
+	}
+	var s Scan
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse scan.json: %w", err)
+	}
+	return &s, nil
+}
+
+// Save writes scan.json atomically, refreshing UpdatedAt and seeding
+// CreatedAt the first time around.
+func (s *Scan) Save(p BrainPaths) error {
+	now := nowISO()
+	if s.CreatedAt == "" {
+		s.CreatedAt = now
+	}
+	s.UpdatedAt = now
+	if err := os.MkdirAll(p.Dir, 0o755); err != nil {
+		return fmt.Errorf("crear %s: %w", p.Dir, err)
+	}
+	return writeJSONAtomic(p.ScanFile, s)
+}
+
+// newScan returns an empty Scan with allocated slices/maps so detectors
+// can append without nil checks.
+func newScan(projectName string) *Scan {
+	return &Scan{
+		Version:       ScanVersion,
+		ProjectName:   projectName,
+		ProjectType:   ProjectTypeUnknown,
+		Platforms:     []string{},
+		BuildSystems:  []string{},
+		UI:            []string{},
+		DI:            []string{},
+		Network:       []string{},
+		Persistence:   []string{},
+		Serialization: []string{},
+		Testing:       []string{},
+		Integrations:  []string{},
+		CICD:          []string{},
+		DetectedFiles: map[string]string{},
+		Warnings:      []string{},
+	}
+}

--- a/cli/internal/brain/scanner.go
+++ b/cli/internal/brain/scanner.go
@@ -20,22 +20,30 @@ const maxScanDepth = 6
 const maxFileSize = 1 << 20 // 1 MiB
 
 // skipDirs are directory names ignored during the walk regardless of
-// depth. Mostly noise: VCS, build outputs, IDE state, vendor caches.
+// depth. Mostly noise: VCS, build outputs, IDE state, vendor caches,
+// and AI-agent workspaces (which often contain full repo copies and
+// would duplicate every signal).
 var skipDirs = map[string]struct{}{
-	".git":       {},
-	".mobiai":    {},
-	".gradle":    {},
-	".idea":      {},
-	".kotlin":    {},
-	".dart_tool": {},
-	".swiftpm":   {},
-	"build":      {},
-	"out":        {},
-	"target":     {},
+	".git":         {},
+	".mobiai":      {},
+	".gradle":      {},
+	".idea":        {},
+	".kotlin":      {},
+	".dart_tool":   {},
+	".swiftpm":     {},
+	"build":        {},
+	"out":          {},
+	"target":       {},
 	"node_modules": {},
-	"Pods":       {},
-	"DerivedData": {},
-	"vendor":     {},
+	"Pods":         {},
+	"DerivedData":  {},
+	"vendor":       {},
+	".claude":      {},
+	".cursor":      {},
+	".copilot":     {},
+	".gemini":      {},
+	".codex":       {},
+	".junie":       {},
 }
 
 // interestingFiles lists the basenames whose full content we slurp into

--- a/cli/internal/brain/scanner.go
+++ b/cli/internal/brain/scanner.go
@@ -1,0 +1,270 @@
+package brain
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// maxScanDepth is the deepest directory level (relative to the project
+// root) the scanner descends into. 6 is plenty for typical mobile
+// monorepos and keeps the walk fast on big trees.
+const maxScanDepth = 6
+
+// maxFileSize is the largest file the scanner is willing to read into
+// memory for content matching. Anything bigger is skipped (binary blobs,
+// generated artefacts).
+const maxFileSize = 1 << 20 // 1 MiB
+
+// skipDirs are directory names ignored during the walk regardless of
+// depth. Mostly noise: VCS, build outputs, IDE state, vendor caches.
+var skipDirs = map[string]struct{}{
+	".git":       {},
+	".mobiai":    {},
+	".gradle":    {},
+	".idea":      {},
+	".kotlin":    {},
+	".dart_tool": {},
+	".swiftpm":   {},
+	"build":      {},
+	"out":        {},
+	"target":     {},
+	"node_modules": {},
+	"Pods":       {},
+	"DerivedData": {},
+	"vendor":     {},
+}
+
+// interestingFiles lists the basenames whose full content we slurp into
+// the index for downstream regex/string matching. The rest of the tree
+// is recorded by path only (presence checks, suffix checks).
+var interestingFiles = map[string]struct{}{
+	"build.gradle":         {},
+	"build.gradle.kts":     {},
+	"settings.gradle":      {},
+	"settings.gradle.kts":  {},
+	"pubspec.yaml":         {},
+	"pubspec.lock":         {},
+	"package.json":         {},
+	"metro.config.js":      {},
+	"Podfile":              {},
+	"Package.swift":        {},
+	"AndroidManifest.xml":  {},
+	"libs.versions.toml":   {},
+	"gradle.properties":    {},
+	"google-services.json": {},
+}
+
+// scanIndex captures everything the detectors need: opened files
+// (full content) and a flat list of all paths walked.
+type scanIndex struct {
+	root     string
+	files    map[string][]byte // relpath → content (only for interestingFiles)
+	allPaths map[string]bool   // relpath → isDir (every entry visited)
+}
+
+func newScanIndex(root string) *scanIndex {
+	return &scanIndex{
+		root:     root,
+		files:    map[string][]byte{},
+		allPaths: map[string]bool{},
+	}
+}
+
+// hasFile reports whether a file with relpath was seen (relative to root).
+func (i *scanIndex) hasFile(relpath string) bool {
+	isDir, ok := i.allPaths[relpath]
+	return ok && !isDir
+}
+
+// hasDir reports whether a directory with relpath was seen.
+func (i *scanIndex) hasDir(relpath string) bool {
+	isDir, ok := i.allPaths[relpath]
+	return ok && isDir
+}
+
+// hasAnyFileSuffix reports whether any indexed path ends with suffix.
+func (i *scanIndex) hasAnyFileSuffix(suffix string) bool {
+	for p, isDir := range i.allPaths {
+		if !isDir && strings.HasSuffix(p, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAnyDirSuffix reports whether any indexed directory path ends with
+// suffix (e.g. "/commonMain", "/composeApp").
+func (i *scanIndex) hasAnyDirSuffix(suffix string) bool {
+	for p, isDir := range i.allPaths {
+		if !isDir {
+			continue
+		}
+		if p == strings.TrimPrefix(suffix, "/") || strings.HasSuffix(p, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// content returns the bytes of an interesting file, or nil if not loaded.
+func (i *scanIndex) content(relpath string) []byte {
+	return i.files[relpath]
+}
+
+// containsAny scans all loaded file contents for needle (case-insensitive)
+// and returns true at the first hit.
+func (i *scanIndex) containsAny(needle string) bool {
+	low := strings.ToLower(needle)
+	for _, content := range i.files {
+		if strings.Contains(strings.ToLower(string(content)), low) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScanProject walks the project at root, builds a scan index, runs the
+// platform detectors and returns a populated Scan. It never fails on
+// individual file read errors — those are recorded as warnings.
+func ScanProject(root string) (*Scan, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("absolutizar root: %w", err)
+	}
+	if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("root no es un directorio: %s", abs)
+	}
+
+	idx := newScanIndex(abs)
+	if err := buildIndex(idx); err != nil {
+		return nil, err
+	}
+
+	s := newScan(filepath.Base(abs))
+	platforms := map[string]struct{}{}
+	types := map[string]struct{}{}
+
+	detectAndroid(idx, s, types, platforms)
+	detectKMP(idx, s, types, platforms)
+	detectFlutter(idx, s, types, platforms)
+	detectIOS(idx, s, types, platforms)
+	detectReactNative(idx, s, types, platforms)
+	detectDeps(idx, s)
+
+	s.ProjectType = pickProjectType(types)
+	s.Platforms = sortedKeys(platforms)
+	dedupAllBuckets(s)
+	return s, nil
+}
+
+// buildIndex walks the tree, applies skip rules and depth cap, and reads
+// the content of interesting files into the index.
+func buildIndex(idx *scanIndex) error {
+	return filepath.WalkDir(idx.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Don't abort the entire scan because one entry is unreadable.
+			return nil
+		}
+		if path == idx.root {
+			return nil
+		}
+		rel, rerr := filepath.Rel(idx.root, path)
+		if rerr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		depth := strings.Count(rel, "/") + 1
+		if depth > maxScanDepth {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if _, skip := skipDirs[d.Name()]; skip {
+				return fs.SkipDir
+			}
+			idx.allPaths[rel] = true
+			return nil
+		}
+		idx.allPaths[rel] = false
+		base := filepath.Base(path)
+		if _, ok := interestingFiles[base]; !ok {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil || info.Size() > maxFileSize {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		idx.files[rel] = data
+		return nil
+	})
+}
+
+// pickProjectType applies precedence: KMP > Flutter > RN > Android > iOS.
+// KMP wins over Android because a KMP project usually contains an Android
+// module. Flutter and RN win over their host platforms for the same reason.
+func pickProjectType(types map[string]struct{}) string {
+	for _, t := range []string{
+		ProjectTypeKMP,
+		ProjectTypeFlutter,
+		ProjectTypeReactNative,
+		ProjectTypeAndroid,
+		ProjectTypeIOS,
+	} {
+		if _, ok := types[t]; ok {
+			return t
+		}
+	}
+	return ProjectTypeUnknown
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// dedupAllBuckets normalizes every []string field on Scan: sorts and
+// deduplicates. Keeps scan.json diffs minimal between runs.
+func dedupAllBuckets(s *Scan) {
+	s.Platforms = dedupSorted(s.Platforms)
+	s.BuildSystems = dedupSorted(s.BuildSystems)
+	s.UI = dedupSorted(s.UI)
+	s.DI = dedupSorted(s.DI)
+	s.Network = dedupSorted(s.Network)
+	s.Persistence = dedupSorted(s.Persistence)
+	s.Serialization = dedupSorted(s.Serialization)
+	s.Testing = dedupSorted(s.Testing)
+	s.Integrations = dedupSorted(s.Integrations)
+	s.CICD = dedupSorted(s.CICD)
+	s.Warnings = dedupSorted(s.Warnings)
+}
+
+func dedupSorted(in []string) []string {
+	if len(in) == 0 {
+		return []string{}
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/internal/brain/scanner.go
+++ b/cli/internal/brain/scanner.go
@@ -49,21 +49,38 @@ var skipDirs = map[string]struct{}{
 // interestingFiles lists the basenames whose full content we slurp into
 // the index for downstream regex/string matching. The rest of the tree
 // is recorded by path only (presence checks, suffix checks).
+//
+// Sensitive files (Firebase configs, .env, signing material) are NOT in
+// this list — they're flagged by `detectSensitiveFiles` via path-only
+// checks so we never load their bytes. See `sensitiveBasenames` below
+// for the explicit denylist enforced in buildIndex.
 var interestingFiles = map[string]struct{}{
-	"build.gradle":         {},
-	"build.gradle.kts":     {},
-	"settings.gradle":      {},
-	"settings.gradle.kts":  {},
-	"pubspec.yaml":         {},
-	"pubspec.lock":         {},
-	"package.json":         {},
-	"metro.config.js":      {},
-	"Podfile":              {},
-	"Package.swift":        {},
-	"AndroidManifest.xml":  {},
-	"libs.versions.toml":   {},
-	"gradle.properties":    {},
-	"google-services.json": {},
+	"build.gradle":        {},
+	"build.gradle.kts":    {},
+	"settings.gradle":     {},
+	"settings.gradle.kts": {},
+	"pubspec.yaml":        {},
+	"pubspec.lock":        {},
+	"package.json":        {},
+	"metro.config.js":     {},
+	"Podfile":             {},
+	"Package.swift":       {},
+	"AndroidManifest.xml": {},
+	"libs.versions.toml":  {},
+	"gradle.properties":   {},
+}
+
+// sensitiveBasenames are file basenames the scanner refuses to read
+// regardless of context. Defense-in-depth: even if a future change adds
+// one of these to interestingFiles by mistake, buildIndex still rejects
+// it. Their *presence* is still reported via detectSensitiveFiles, just
+// without ever loading bytes into memory.
+var sensitiveBasenames = map[string]struct{}{
+	".env":                     {},
+	"google-services.json":     {},
+	"GoogleService-Info.plist": {},
+	"local.properties":         {},
+	"keystore.properties":      {},
 }
 
 // scanIndex captures everything the detectors need: opened files
@@ -72,6 +89,7 @@ type scanIndex struct {
 	root     string
 	files    map[string][]byte // relpath → content (only for interestingFiles)
 	allPaths map[string]bool   // relpath → isDir (every entry visited)
+	warnings []string          // unexpected read errors during the walk
 }
 
 func newScanIndex(root string) *scanIndex {
@@ -136,8 +154,11 @@ func (i *scanIndex) containsAny(needle string) bool {
 }
 
 // ScanProject walks the project at root, builds a scan index, runs the
-// platform detectors and returns a populated Scan. It never fails on
-// individual file read errors — those are recorded as warnings.
+// platform detectors and returns a populated Scan. The walk never aborts
+// on a per-entry error: if reading an interesting file fails, the path
+// is recorded in scan.Warnings so the user sees what was missed. Depth
+// and size limits are enforced silently (they're a scanner choice, not
+// a problem with the file itself).
 func ScanProject(root string) (*Scan, error) {
 	abs, err := filepath.Abs(root)
 	if err != nil {
@@ -153,6 +174,7 @@ func ScanProject(root string) (*Scan, error) {
 	}
 
 	s := newScan(filepath.Base(abs))
+	s.Warnings = append(s.Warnings, idx.warnings...)
 	platforms := map[string]struct{}{}
 	types := map[string]struct{}{}
 
@@ -201,6 +223,13 @@ func buildIndex(idx *scanIndex) error {
 		}
 		idx.allPaths[rel] = false
 		base := filepath.Base(path)
+		if _, ok := sensitiveBasenames[base]; ok {
+			// Hard guard: never load the bytes of files known to carry
+			// secrets, even if some future change adds them to
+			// interestingFiles. Their presence is still reported
+			// downstream by detectSensitiveFiles via the path index.
+			return nil
+		}
 		if _, ok := interestingFiles[base]; !ok {
 			return nil
 		}
@@ -210,6 +239,8 @@ func buildIndex(idx *scanIndex) error {
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
+			idx.warnings = append(idx.warnings,
+				fmt.Sprintf("no se pudo leer %s: %v", rel, err))
 			return nil
 		}
 		idx.files[rel] = data

--- a/cli/internal/brain/scanner_test.go
+++ b/cli/internal/brain/scanner_test.go
@@ -3,6 +3,7 @@ package brain
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -298,6 +299,13 @@ func TestScan_NeverReadsSensitiveFileContent(t *testing.T) {
 }
 
 func TestScan_ReportsUnreadableInterestingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows ignores Unix permission bits on regular files, so
+		// chmod 0o000 doesn't actually make the file unreadable.
+		// The behavior under test (warning on os.ReadFile error) is
+		// cross-platform; only this way of triggering the error isn't.
+		t.Skip("chmod-based unreadable file does not work on Windows")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("running as root — chmod-based unreadable test is meaningless")
 	}

--- a/cli/internal/brain/scanner_test.go
+++ b/cli/internal/brain/scanner_test.go
@@ -1,0 +1,223 @@
+package brain
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScan_AndroidProject(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "settings.gradle.kts"), `rootProject.name = "app"`)
+	mustWrite(t, filepath.Join(root, "app", "build.gradle.kts"),
+		"plugins { id(\"com.android.application\") }\n"+
+			"dependencies { implementation(\"androidx.compose.ui:ui:1.6.0\") }\n"+
+			"dependencies { implementation(\"com.google.dagger.hilt.android:hilt-android:2.50\") }\n")
+	mustWrite(t, filepath.Join(root, "app", "src", "main", "AndroidManifest.xml"),
+		`<manifest package="com.example"/>`)
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.ProjectType != ProjectTypeAndroid {
+		t.Errorf("ProjectType = %q, want %q", s.ProjectType, ProjectTypeAndroid)
+	}
+	if !contains(s.Platforms, PlatformAndroid) {
+		t.Errorf("Platforms = %v, want android", s.Platforms)
+	}
+	if !contains(s.UI, "compose") {
+		t.Errorf("UI = %v, want compose", s.UI)
+	}
+	if !contains(s.DI, "hilt") {
+		t.Errorf("DI = %v, want hilt", s.DI)
+	}
+	if !contains(s.BuildSystems, "gradle") {
+		t.Errorf("BuildSystems = %v, want gradle", s.BuildSystems)
+	}
+}
+
+func TestScan_KMPProject_WithComposeAndKoin(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "settings.gradle.kts"), `rootProject.name = "kmp"`)
+	mustWrite(t, filepath.Join(root, "composeApp", "build.gradle.kts"),
+		"plugins { kotlin(\"multiplatform\") }\n"+
+			"dependencies { implementation(\"io.insert-koin:koin-core:3.5.0\") }\n"+
+			"dependencies { implementation(\"org.jetbrains.compose.runtime:runtime:1.6.0\") }\n"+
+			"dependencies { implementation(\"io.ktor:ktor-client-core:2.3.0\") }\n")
+	mustMkdir(t, filepath.Join(root, "composeApp", "src", "commonMain"))
+	mustMkdir(t, filepath.Join(root, "composeApp", "src", "androidMain"))
+	mustMkdir(t, filepath.Join(root, "composeApp", "src", "iosMain"))
+	mustWrite(t, filepath.Join(root, "composeApp", "src", "androidMain", "AndroidManifest.xml"),
+		`<manifest/>`)
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.ProjectType != ProjectTypeKMP {
+		t.Errorf("ProjectType = %q, want %q", s.ProjectType, ProjectTypeKMP)
+	}
+	for _, want := range []string{PlatformAndroid, PlatformIOS, PlatformShared} {
+		if !contains(s.Platforms, want) {
+			t.Errorf("Platforms = %v, missing %q", s.Platforms, want)
+		}
+	}
+	if !contains(s.DI, "koin") {
+		t.Errorf("DI = %v, want koin", s.DI)
+	}
+	if !contains(s.UI, "compose_multiplatform") {
+		t.Errorf("UI = %v, want compose_multiplatform", s.UI)
+	}
+	if !contains(s.Network, "ktor") {
+		t.Errorf("Network = %v, want ktor", s.Network)
+	}
+}
+
+func TestScan_FlutterProject(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "pubspec.yaml"),
+		"name: app\nflutter:\n  uses-material-design: true\n")
+	mustMkdir(t, filepath.Join(root, "android"))
+	mustMkdir(t, filepath.Join(root, "ios"))
+	mustMkdir(t, filepath.Join(root, "lib"))
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.ProjectType != ProjectTypeFlutter {
+		t.Errorf("ProjectType = %q, want %q", s.ProjectType, ProjectTypeFlutter)
+	}
+	for _, want := range []string{PlatformAndroid, PlatformIOS} {
+		if !contains(s.Platforms, want) {
+			t.Errorf("Platforms = %v, missing %q", s.Platforms, want)
+		}
+	}
+	if s.DetectedFiles["pubspec_yaml"] != "pubspec.yaml" {
+		t.Errorf("DetectedFiles[pubspec_yaml] = %q", s.DetectedFiles["pubspec_yaml"])
+	}
+}
+
+func TestScan_IOSWithPodfile(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "Podfile"), "platform :ios, '15.0'\n")
+	mustMkdir(t, filepath.Join(root, "App.xcodeproj"))
+	mustWrite(t, filepath.Join(root, "App", "View.swift"), "import SwiftUI\n")
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.ProjectType != ProjectTypeIOS {
+		t.Errorf("ProjectType = %q, want %q", s.ProjectType, ProjectTypeIOS)
+	}
+	if !contains(s.Platforms, PlatformIOS) {
+		t.Errorf("Platforms = %v, want ios", s.Platforms)
+	}
+	if !contains(s.BuildSystems, "cocoapods") {
+		t.Errorf("BuildSystems = %v, want cocoapods", s.BuildSystems)
+	}
+}
+
+func TestScan_ReactNativeProject(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "package.json"),
+		`{"name":"app","dependencies":{"react-native":"0.74.0"}}`)
+	mustWrite(t, filepath.Join(root, "metro.config.js"), "module.exports = {};\n")
+	mustMkdir(t, filepath.Join(root, "android"))
+	mustMkdir(t, filepath.Join(root, "ios"))
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.ProjectType != ProjectTypeReactNative {
+		t.Errorf("ProjectType = %q, want %q", s.ProjectType, ProjectTypeReactNative)
+	}
+	for _, want := range []string{PlatformAndroid, PlatformIOS} {
+		if !contains(s.Platforms, want) {
+			t.Errorf("Platforms = %v, missing %q", s.Platforms, want)
+		}
+	}
+	if !contains(s.BuildSystems, "npm") {
+		t.Errorf("BuildSystems = %v, want npm", s.BuildSystems)
+	}
+}
+
+func TestScan_DetectsGitHubActions(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "settings.gradle.kts"), "")
+	mustMkdir(t, filepath.Join(root, ".github", "workflows"))
+	mustWrite(t, filepath.Join(root, ".github", "workflows", "ci.yml"), "name: CI\n")
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(s.CICD, "github_actions") {
+		t.Errorf("CICD = %v, want github_actions", s.CICD)
+	}
+}
+
+func TestScan_FlagsSensitiveFilesWithoutReading(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "settings.gradle.kts"), "")
+	mustWrite(t, filepath.Join(root, ".env"), "API_KEY=should_not_be_read")
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := false
+	for _, w := range s.Warnings {
+		if strings.Contains(w, ".env") {
+			hit = true
+		}
+		if strings.Contains(w, "should_not_be_read") {
+			t.Error("scanner leaked .env content into warnings")
+		}
+	}
+	if !hit {
+		t.Errorf("Warnings = %v, want one mentioning .env", s.Warnings)
+	}
+}
+
+func TestScan_SkipsNoiseDirs(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "settings.gradle.kts"), "")
+	// Place a fake settings.gradle.kts inside a build/ dir — must be ignored.
+	mustWrite(t, filepath.Join(root, "build", "settings.gradle.kts"), "")
+	mustMkdir(t, filepath.Join(root, "node_modules", "react-native"))
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for path := range s.DetectedFiles {
+		if strings.Contains(s.DetectedFiles[path], "build/") ||
+			strings.Contains(s.DetectedFiles[path], "node_modules/") {
+			t.Errorf("DetectedFiles leaked noise dir: %q", s.DetectedFiles[path])
+		}
+	}
+}
+
+func TestScan_EmptyDirectoryIsUnknown(t *testing.T) {
+	root := t.TempDir()
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.ProjectType != ProjectTypeUnknown {
+		t.Errorf("ProjectType = %q, want unknown", s.ProjectType)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/brain/scanner_test.go
+++ b/cli/internal/brain/scanner_test.go
@@ -202,6 +202,36 @@ func TestScan_SkipsNoiseDirs(t *testing.T) {
 	}
 }
 
+func TestScan_SkipsAgentWorkspaceDirs(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "settings.gradle.kts"), "")
+	// Real .env at root must be flagged.
+	mustWrite(t, filepath.Join(root, ".env"), "API_KEY=x")
+	// Copies inside agent workspaces (Claude Code worktrees, Cursor, etc.)
+	// must NOT appear in warnings — those are full repo clones and would
+	// produce duplicate signals on every run.
+	mustWrite(t, filepath.Join(root, ".claude", "worktrees", "abc", ".env"), "API_KEY=x")
+	mustWrite(t, filepath.Join(root, ".claude", "worktrees", "abc", "GoogleService-Info.plist"), "")
+	mustWrite(t, filepath.Join(root, ".cursor", "session", "google-services.json"), "")
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envWarnings := 0
+	for _, w := range s.Warnings {
+		if strings.Contains(w, ".claude/") || strings.Contains(w, ".cursor/") {
+			t.Errorf("agent workspace leaked into warnings: %q", w)
+		}
+		if strings.Contains(w, ".env") {
+			envWarnings++
+		}
+	}
+	if envWarnings != 1 {
+		t.Errorf(".env should be flagged exactly once, got %d (warnings=%v)", envWarnings, s.Warnings)
+	}
+}
+
 func TestScan_EmptyDirectoryIsUnknown(t *testing.T) {
 	root := t.TempDir()
 	s, err := ScanProject(root)

--- a/cli/internal/brain/scanner_test.go
+++ b/cli/internal/brain/scanner_test.go
@@ -1,6 +1,7 @@
 package brain
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -229,6 +230,98 @@ func TestScan_SkipsAgentWorkspaceDirs(t *testing.T) {
 	}
 	if envWarnings != 1 {
 		t.Errorf(".env should be flagged exactly once, got %d (warnings=%v)", envWarnings, s.Warnings)
+	}
+}
+
+func TestScan_NeverReadsSensitiveFileContent(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "settings.gradle.kts"), "")
+	// google-services.json (Firebase config) frequently contains an
+	// `api_key` value. The scanner must NEVER load this content into
+	// the index — neither in idx.files nor reachable via containsAny.
+	const secret = "AIzaSy-FAKE-FIREBASE-KEY-DO-NOT-LEAK"
+	mustWrite(t, filepath.Join(root, "composeApp", "src", "google-services.json"),
+		`{"client":[{"api_key":[{"current_key":"`+secret+`"}]}]}`)
+	mustWrite(t, filepath.Join(root, "iosApp", "GoogleService-Info.plist"),
+		`<?xml version="1.0"?>
+<plist><dict><key>API_KEY</key><string>`+secret+`</string></dict></plist>`)
+	mustWrite(t, filepath.Join(root, "local.properties"),
+		"sdk.dir=/Users/me/Android/sdk\nMAPS_API_KEY="+secret)
+	mustWrite(t, filepath.Join(root, ".env"), "API_KEY="+secret)
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range s.Warnings {
+		if strings.Contains(w, secret) {
+			t.Errorf("warnings leaked secret: %q", w)
+		}
+	}
+	// Round-trip the scan to JSON and verify the secret never makes it
+	// into anything we'd persist on disk.
+	tmp := t.TempDir()
+	p := NewBrainPaths(tmp)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(p); err != nil {
+		t.Fatal(err)
+	}
+	persisted, err := os.ReadFile(p.ScanFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(persisted), secret) {
+		t.Errorf("scan.json persisted the secret")
+	}
+
+	// All four sensitive files should still be flagged via path-only
+	// detection (no content read involved).
+	wantWarnings := []string{
+		".env",
+		"google-services.json",
+		"GoogleService-Info.plist",
+	}
+	for _, want := range wantWarnings {
+		hit := false
+		for _, w := range s.Warnings {
+			if strings.Contains(w, want) {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			t.Errorf("expected warning mentioning %q; got: %v", want, s.Warnings)
+		}
+	}
+}
+
+func TestScan_ReportsUnreadableInterestingFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — chmod-based unreadable test is meaningless")
+	}
+	root := t.TempDir()
+	gradleFile := filepath.Join(root, "build.gradle.kts")
+	mustWrite(t, gradleFile, `plugins { id("com.android.application") }`)
+	if err := os.Chmod(gradleFile, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(gradleFile, 0o644) })
+
+	s, err := ScanProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := false
+	for _, w := range s.Warnings {
+		if strings.Contains(w, "no se pudo leer") && strings.Contains(w, "build.gradle.kts") {
+			hit = true
+			break
+		}
+	}
+	if !hit {
+		t.Errorf("expected read-error warning for build.gradle.kts; got: %v", s.Warnings)
 	}
 }
 

--- a/cli/internal/cmd/brain.go
+++ b/cli/internal/cmd/brain.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/brain"
+)
+
+// NewBrainCmd builds `mobiai brain <init|scan|context>`.
+//
+// Phase 1 of MobiAI Brain — a per-project memory layer for mobile agents.
+// All state lives inside the project at <root>/.mobiai/brain/, never in
+// the global ~/.mobiai/ directory (that's the CLI's own state).
+func NewBrainCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "brain",
+		Short: "Memoria por proyecto para agentes mobile",
+		Long: "MobiAI Brain guarda contexto vivo por proyecto: stack detectado, " +
+			"decisiones, bugfixes, patrones de testing e integraciones. " +
+			"Vive en <repo>/.mobiai/brain/ — separado del estado global de la CLI.",
+	}
+	root.AddCommand(newBrainInitCmd(), newBrainScanCmd(), newBrainContextCmd())
+	return root
+}
+
+// brainCommonFlags wires up shared --root/--cwd flags on a leaf command.
+// Both flags resolve to the same value (the project root); having two
+// names lets users pick whichever reads better in their shell history.
+func brainCommonFlags(c *cobra.Command) {
+	c.Flags().String("root", "", "ruta del proyecto (default: detectado desde el cwd)")
+}
+
+// resolveBrainRoot returns the project root for a brain command. It
+// honors --root if given; otherwise it walks up from cwd looking for
+// project markers (see brain.FindProjectRoot).
+func resolveBrainRoot(c *cobra.Command) (brain.RootInfo, error) {
+	if explicit, _ := c.Flags().GetString("root"); explicit != "" {
+		abs, err := filepath.Abs(explicit)
+		if err != nil {
+			return brain.RootInfo{}, fmt.Errorf("absolutizar --root: %w", err)
+		}
+		if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+			return brain.RootInfo{}, fmt.Errorf("--root no es un directorio: %s", abs)
+		}
+		return brain.RootInfo{Path: abs, Source: brain.RootSourceCwd}, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return brain.RootInfo{}, fmt.Errorf("getwd: %w", err)
+	}
+	return brain.FindProjectRoot(cwd)
+}
+
+func newBrainInitCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "init",
+		Short: "Inicializa .mobiai/brain en el proyecto actual",
+		RunE:  runBrainInit,
+	}
+	brainCommonFlags(c)
+	return c
+}
+
+func runBrainInit(c *cobra.Command, _ []string) error {
+	out := c.OutOrStdout()
+	info, err := resolveBrainRoot(c)
+	if err != nil {
+		return err
+	}
+	if info.Warning != "" {
+		fmt.Fprintf(out, "⚠ %s (usando %s)\n", info.Warning, info.Path)
+	} else {
+		fmt.Fprintf(out, "Proyecto detectado: %s\n", info.Path)
+	}
+
+	paths := brain.NewBrainPaths(info.Path)
+	if err := paths.EnsureDirs(); err != nil {
+		return err
+	}
+
+	createdConfig := false
+	if _, err := os.Stat(paths.ConfigFile); os.IsNotExist(err) {
+		cfg := brain.DefaultConfig(info.Path)
+		if err := cfg.Save(paths); err != nil {
+			return err
+		}
+		createdConfig = true
+	} else if err != nil {
+		return fmt.Errorf("stat config.json: %w", err)
+	}
+
+	createdMemories, err := brain.EnsureMemoryFiles(paths)
+	if err != nil {
+		return err
+	}
+
+	if createdConfig {
+		fmt.Fprintf(out, "✓ creado %s\n", relTo(info.Path, paths.ConfigFile))
+	} else {
+		fmt.Fprintf(out, "= %s ya existe (no se sobrescribe)\n", relTo(info.Path, paths.ConfigFile))
+	}
+	if len(createdMemories) > 0 {
+		fmt.Fprintf(out, "✓ memorias inicializadas: %s\n", strings.Join(createdMemories, ", "))
+	} else {
+		fmt.Fprintln(out, "= memorias ya existentes (no se sobrescriben)")
+	}
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Siguiente paso: `mobiai brain scan` para detectar el stack.")
+	return nil
+}
+
+func newBrainScanCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "scan",
+		Short: "Escanea el proyecto y detecta el stack mobile",
+		RunE:  runBrainScan,
+	}
+	brainCommonFlags(c)
+	return c
+}
+
+func runBrainScan(c *cobra.Command, _ []string) error {
+	out := c.OutOrStdout()
+	info, err := resolveBrainRoot(c)
+	if err != nil {
+		return err
+	}
+	paths := brain.NewBrainPaths(info.Path)
+	if !paths.Exists() {
+		return fmt.Errorf("no encontré .mobiai/brain/config.json en %s. Corré `mobiai brain init` primero", info.Path)
+	}
+
+	fmt.Fprintf(out, "Escaneando %s ...\n", info.Path)
+	scan, err := brain.ScanProject(info.Path)
+	if err != nil {
+		return err
+	}
+
+	// Reflect the scan result back into config.json so subsequent
+	// `brain context` runs see the freshest project_type and platforms
+	// without forcing the user to edit the file by hand.
+	cfg, err := brain.LoadConfig(paths)
+	if err != nil {
+		return fmt.Errorf("leer config.json: %w", err)
+	}
+	if cfg.ProjectType == brain.ProjectTypeUnknown {
+		cfg.ProjectType = scan.ProjectType
+	}
+	if len(cfg.Platforms) == 0 {
+		cfg.Platforms = append([]string(nil), scan.Platforms...)
+	}
+	if err := cfg.Save(paths); err != nil {
+		return err
+	}
+	if err := scan.Save(paths); err != nil {
+		return err
+	}
+
+	printScanSummary(out, scan)
+	fmt.Fprintf(out, "✓ scan guardado en %s\n", relTo(info.Path, paths.ScanFile))
+	return nil
+}
+
+func printScanSummary(out io.Writer, s *brain.Scan) {
+	w := func(format string, args ...interface{}) {
+		fmt.Fprintf(out, format, args...)
+	}
+	w("\nResumen:\n")
+	w("  Tipo:        %s\n", s.ProjectType)
+	if len(s.Platforms) > 0 {
+		w("  Plataformas: %s\n", strings.Join(s.Platforms, ", "))
+	}
+	for _, row := range []struct {
+		label string
+		items []string
+	}{
+		{"UI", s.UI},
+		{"DI", s.DI},
+		{"Network", s.Network},
+		{"Persistence", s.Persistence},
+		{"Testing", s.Testing},
+		{"Integrations", s.Integrations},
+		{"CI/CD", s.CICD},
+	} {
+		if len(row.items) == 0 {
+			continue
+		}
+		w("  %-12s %s\n", row.label+":", strings.Join(row.items, ", "))
+	}
+	if len(s.Warnings) > 0 {
+		w("  Warnings:    %d\n", len(s.Warnings))
+	}
+	w("\n")
+}
+
+func newBrainContextCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "context",
+		Short: "Imprime el contexto Markdown del Brain (config + scan + memorias)",
+		RunE:  runBrainContext,
+	}
+	brainCommonFlags(c)
+	return c
+}
+
+func runBrainContext(c *cobra.Command, _ []string) error {
+	info, err := resolveBrainRoot(c)
+	if err != nil {
+		return err
+	}
+	paths := brain.NewBrainPaths(info.Path)
+	if !paths.Exists() {
+		return fmt.Errorf("no encontré .mobiai/brain/config.json en %s. Corré `mobiai brain init` primero", info.Path)
+	}
+	cfg, err := brain.LoadConfig(paths)
+	if err != nil {
+		return err
+	}
+	scan, err := brain.LoadScan(paths)
+	if err != nil {
+		return err
+	}
+	md := brain.BuildContext(cfg, scan, paths)
+	fmt.Fprint(c.OutOrStdout(), md)
+	return nil
+}
+
+// relTo returns target relative to base, falling back to the absolute
+// path when filepath.Rel fails (e.g. on different volumes).
+func relTo(base, target string) string {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return target
+	}
+	return rel
+}

--- a/cli/internal/cmd/brain.go
+++ b/cli/internal/cmd/brain.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -25,7 +26,7 @@ func NewBrainCmd() *cobra.Command {
 			"decisiones, bugfixes, patrones de testing e integraciones. " +
 			"Vive en <repo>/.mobiai/brain/ — separado del estado global de la CLI.",
 	}
-	root.AddCommand(newBrainInitCmd(), newBrainScanCmd(), newBrainContextCmd())
+	root.AddCommand(newBrainInitCmd(), newBrainScanCmd(), newBrainContextCmd(), newBrainSaveCmd())
 	return root
 }
 
@@ -229,6 +230,127 @@ func runBrainContext(c *cobra.Command, _ []string) error {
 	md := brain.BuildContext(cfg, scan, paths)
 	fmt.Fprint(c.OutOrStdout(), md)
 	return nil
+}
+
+func newBrainSaveCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "save",
+		Short: "Guardar una entrada en las memorias del Brain",
+		Long: "Añade una entrada estructurada al archivo de memoria correspondiente. " +
+			"Requiere que el Brain esté inicializado en el proyecto " +
+			"(corré `mobiai brain init` primero).",
+	}
+	root.AddCommand(
+		newBrainSaveSubCmd(brain.SaveTypeDecision, "decision",
+			"Guardar una decisión de arquitectura"),
+		newBrainSaveSubCmd(brain.SaveTypeBugfix, "bugfix",
+			"Guardar un bugfix o workaround"),
+		newBrainSaveSubCmd(brain.SaveTypeTesting, "testing",
+			"Guardar un patrón de testing reusable"),
+	)
+	return root
+}
+
+func newBrainSaveSubCmd(saveType brain.SaveType, use, short string) *cobra.Command {
+	c := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runBrainSave(cmd, saveType)
+		},
+	}
+	brainCommonFlags(c)
+	c.Flags().String("title", "", "título corto de la entrada (requerido)")
+	c.Flags().String("platform", "", "android|ios|shared|kmp|flutter|react-native (opcional)")
+	c.Flags().String("area", "", "área del proyecto (libre, opcional)")
+	c.Flags().String("status", "active", "active|temporary|deprecated")
+	c.Flags().String("review-after", "", "fecha YYYY-MM-DD para revisar (opcional)")
+	c.Flags().String("body", "", "cuerpo Markdown (si se omite, se lee de stdin)")
+	c.Flags().StringSlice("files", nil, "archivos relacionados, separados por coma (opcional)")
+	_ = c.MarkFlagRequired("title")
+	return c
+}
+
+func runBrainSave(c *cobra.Command, saveType brain.SaveType) error {
+	out := c.OutOrStdout()
+	info, err := resolveBrainRoot(c)
+	if err != nil {
+		return err
+	}
+	paths := brain.NewBrainPaths(info.Path)
+	if !paths.Exists() {
+		return fmt.Errorf("brain no inicializado en %s — corré `mobiai brain init` primero", info.Path)
+	}
+
+	title, _ := c.Flags().GetString("title")
+	platform, _ := c.Flags().GetString("platform")
+	area, _ := c.Flags().GetString("area")
+	status, _ := c.Flags().GetString("status")
+	reviewAfter, _ := c.Flags().GetString("review-after")
+	body, _ := c.Flags().GetString("body")
+	files, _ := c.Flags().GetStringSlice("files")
+
+	if body == "" {
+		// stdin fallback: lets the agent pipe a multi-line markdown body
+		// without struggling with shell-escaping a flag value.
+		piped, err := readPipedStdin(c.InOrStdin())
+		if err != nil {
+			return fmt.Errorf("leer body desde stdin: %w", err)
+		}
+		body = piped
+	}
+
+	entry := &brain.SaveEntry{
+		Type:        saveType,
+		Title:       title,
+		Platform:    platform,
+		Area:        area,
+		Status:      status,
+		ReviewAfter: reviewAfter,
+		Body:        body,
+		Files:       files,
+	}
+	id, err := brain.AppendEntry(paths, entry)
+	if err != nil {
+		return err
+	}
+
+	fileBase := map[brain.SaveType]string{
+		brain.SaveTypeDecision: "decisions.md",
+		brain.SaveTypeBugfix:   "bugfixes.md",
+		brain.SaveTypeTesting:  "testing.md",
+	}[saveType]
+	rel := filepath.Join(".mobiai", "brain", "memories", fileBase)
+	fmt.Fprintf(out, "✓ guardado en %s\n  id: %s\n", rel, id)
+	return nil
+}
+
+// readPipedStdin returns stdin content only when stdin is a pipe (not a
+// tty). Returns "" when running interactively so the command doesn't
+// hang waiting for input the user didn't intend to provide.
+func readPipedStdin(in io.Reader) (string, error) {
+	f, ok := in.(*os.File)
+	if ok {
+		stat, err := f.Stat()
+		if err != nil {
+			return "", err
+		}
+		if (stat.Mode() & os.ModeCharDevice) != 0 {
+			// stdin is a terminal — nothing being piped.
+			return "", nil
+		}
+	}
+	var b strings.Builder
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		b.WriteString(scanner.Text())
+		b.WriteString("\n")
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
 }
 
 // relTo returns target relative to base, falling back to the absolute

--- a/cli/internal/cmd/brain.go
+++ b/cli/internal/cmd/brain.go
@@ -30,9 +30,9 @@ func NewBrainCmd() *cobra.Command {
 	return root
 }
 
-// brainCommonFlags wires up shared --root/--cwd flags on a leaf command.
-// Both flags resolve to the same value (the project root); having two
-// names lets users pick whichever reads better in their shell history.
+// brainCommonFlags wires up the shared --root flag on a leaf command.
+// When omitted, the command resolves the project root by walking up
+// from the current working directory (see brain.FindProjectRoot).
 func brainCommonFlags(c *cobra.Command) {
 	c.Flags().String("root", "", "ruta del proyecto (default: detectado desde el cwd)")
 }

--- a/cli/internal/cmd/brain_save_test.go
+++ b/cli/internal/cmd/brain_save_test.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBrainSave_RequiresInit(t *testing.T) {
+	root := setupKMPProject(t)
+	cmd := NewBrainCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"save", "decision",
+		"--root", root,
+		"--title", "x",
+		"--body", "y",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Errorf("save without init should fail; output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "no inicializado") {
+		t.Errorf("error message should mention 'no inicializado'; got:\n%s", buf.String())
+	}
+}
+
+func TestBrainSave_DecisionAppendsToFile(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+
+	out := runBrain(t, []string{
+		"save", "decision",
+		"--root", root,
+		"--title", "Use Koin as DI",
+		"--platform", "shared",
+		"--area", "dependency_injection",
+		"--body", "### Decision\nUse Koin.\n\n### Reason\nKMP-friendly.",
+		"--files", "composeApp/src/commonMain/Module.kt,composeApp/build.gradle.kts",
+	})
+	if !strings.Contains(out, "✓ guardado") {
+		t.Errorf("expected success message, got:\n%s", out)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, ".mobiai", "brain", "memories", "decisions.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"## Use Koin as DI",
+		"- type: architecture_decision",
+		"- platform: shared",
+		"- area: dependency_injection",
+		"### Decision",
+		"### Files",
+		"- composeApp/src/commonMain/Module.kt",
+		"- composeApp/build.gradle.kts",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestBrainSave_BugfixTemporaryWritesReviewAfter(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+
+	_ = runBrain(t, []string{
+		"save", "bugfix",
+		"--root", root,
+		"--title", "FirebaseAuth iOS module name",
+		"--platform", "ios",
+		"--status", "temporary",
+		"--review-after", "2026-09-01",
+		"--body", "### Problem\n...\n\n### Solution\n...",
+	})
+
+	got, err := os.ReadFile(filepath.Join(root, ".mobiai", "brain", "memories", "bugfixes.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"## FirebaseAuth iOS module name",
+		"- type: platform_workaround",
+		"- status: temporary",
+		"- review_after: 2026-09-01",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestBrainSave_MultipleSavesDoNotOverwrite(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+
+	for _, title := range []string{"First", "Second", "Third"} {
+		_ = runBrain(t, []string{
+			"save", "testing",
+			"--root", root,
+			"--title", title,
+			"--body", "body for " + title,
+		})
+	}
+	got, err := os.ReadFile(filepath.Join(root, ".mobiai", "brain", "memories", "testing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"## First", "## Second", "## Third"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestBrainSave_RejectsBadStatus(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+	cmd := NewBrainCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"save", "decision",
+		"--root", root,
+		"--title", "x",
+		"--status", "wat",
+		"--body", "y",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Error("save with invalid status should fail")
+	}
+}
+
+func TestBrainSave_TitleRequired(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+	cmd := NewBrainCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"save", "decision",
+		"--root", root,
+		"--body", "y",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Error("save without --title should fail")
+	}
+}
+
+func TestBrainSave_ContextShowsSavedEntries(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+	_ = runBrain(t, []string{
+		"save", "decision",
+		"--root", root,
+		"--title", "Use Koin",
+		"--body", "### Decision\nUse Koin.",
+	})
+	out := runBrain(t, []string{"context", "--root", root})
+	if !strings.Contains(out, "## Use Koin") {
+		t.Errorf("context should include the saved decision; got:\n%s", out)
+	}
+	// The "_No entries yet._" placeholder should disappear from
+	// Architecture Decisions now that one is saved.
+	idx := strings.Index(out, "## Architecture Decisions")
+	rest := out[idx:]
+	nextSection := strings.Index(rest[len("## Architecture Decisions"):], "##")
+	section := rest
+	if nextSection > 0 {
+		section = rest[:len("## Architecture Decisions")+nextSection]
+	}
+	if strings.Contains(section, "_No entries yet._") {
+		t.Errorf("Architecture Decisions section should not show 'No entries yet' after save:\n%s", section)
+	}
+}

--- a/cli/internal/cmd/brain_test.go
+++ b/cli/internal/cmd/brain_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBrainInit_CreatesStructure(t *testing.T) {
+	root := setupKMPProject(t)
+
+	out := runBrain(t, []string{"init", "--root", root})
+	if !strings.Contains(out, "Proyecto detectado") {
+		t.Errorf("expected detection message, got: %s", out)
+	}
+	if !strings.Contains(out, "config.json") {
+		t.Errorf("expected config.json mention, got: %s", out)
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".mobiai", "brain", "config.json"),
+		filepath.Join(".mobiai", "brain", "memories", "decisions.md"),
+		filepath.Join(".mobiai", "brain", "memories", "bugfixes.md"),
+		filepath.Join(".mobiai", "brain", "memories", "testing.md"),
+		filepath.Join(".mobiai", "brain", "memories", "integrations.md"),
+		filepath.Join(".mobiai", "brain", "memories", "releases.md"),
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Errorf("expected %s to exist: %v", rel, err)
+		}
+	}
+
+	// Re-running init must be idempotent: don't overwrite, and don't error.
+	out2 := runBrain(t, []string{"init", "--root", root})
+	if !strings.Contains(out2, "ya existe") {
+		t.Errorf("second init should mention existing files, got: %s", out2)
+	}
+}
+
+func TestBrainScan_WritesScanJSON(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+
+	out := runBrain(t, []string{"scan", "--root", root})
+	if !strings.Contains(out, "scan guardado") {
+		t.Errorf("expected scan-saved message, got: %s", out)
+	}
+
+	scanPath := filepath.Join(root, ".mobiai", "brain", "scan.json")
+	data, err := os.ReadFile(scanPath)
+	if err != nil {
+		t.Fatalf("read scan.json: %v", err)
+	}
+	var parsed struct {
+		ProjectType string   `json:"project_type"`
+		Platforms   []string `json:"platforms"`
+		DI          []string `json:"di"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse scan.json: %v", err)
+	}
+	if parsed.ProjectType != "kmp" {
+		t.Errorf("project_type = %q, want kmp", parsed.ProjectType)
+	}
+	if !sliceContains(parsed.Platforms, "android") || !sliceContains(parsed.Platforms, "ios") {
+		t.Errorf("platforms = %v, want android+ios", parsed.Platforms)
+	}
+	if !sliceContains(parsed.DI, "koin") {
+		t.Errorf("di = %v, want koin", parsed.DI)
+	}
+}
+
+func TestBrainScan_RequiresInit(t *testing.T) {
+	root := setupKMPProject(t)
+	cmd := NewBrainCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"scan", "--root", root})
+	if err := cmd.Execute(); err == nil {
+		t.Error("scan without init should fail")
+	}
+}
+
+func TestBrainContext_OutputsMarkdown(t *testing.T) {
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+	_ = runBrain(t, []string{"scan", "--root", root})
+
+	out := runBrain(t, []string{"context", "--root", root})
+	for _, want := range []string{
+		"# MobiAI Brain Context",
+		"Type: Kotlin Multiplatform",
+		"## Detected Stack",
+		"- DI: koin",
+		"## Project Rules",
+		"## Architecture Decisions",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("context output missing %q. full output:\n%s", want, out)
+		}
+	}
+}
+
+// runBrain executes a brain subcommand and returns combined stdout/stderr.
+// Fails the test on any execution error.
+func runBrain(t *testing.T, args []string) string {
+	t.Helper()
+	cmd := NewBrainCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("brain %v: %v\noutput:\n%s", args, err, buf.String())
+	}
+	return buf.String()
+}
+
+// setupKMPProject creates a minimal Kotlin Multiplatform tree (Compose
+// Multiplatform + Koin + Android + iOS) and returns its root.
+func setupKMPProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, content string) {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkdir := func(rel string) {
+		if err := os.MkdirAll(filepath.Join(root, rel), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("settings.gradle.kts", `rootProject.name = "demo"`)
+	write("composeApp/build.gradle.kts", `
+plugins { kotlin("multiplatform") }
+dependencies {
+  implementation("io.insert-koin:koin-core:3.5.0")
+  implementation("org.jetbrains.compose.runtime:runtime:1.6.0")
+}
+`)
+	mkdir("composeApp/src/commonMain")
+	mkdir("composeApp/src/androidMain")
+	mkdir("composeApp/src/iosMain")
+	write("composeApp/src/androidMain/AndroidManifest.xml", `<manifest/>`)
+	return root
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -1,0 +1,136 @@
+# MobiAI Brain (preview)
+
+MobiAI Brain es la **memoria viva por proyecto** del ecosistema MobiAI. Mientras las skills enseñan a la IA *cómo* trabajar, el Brain guarda el *conocimiento específico* de cada proyecto mobile: decisiones, bugfixes, workarounds, patrones de testing e integraciones.
+
+> Esta es la Fase 1 (`init` + `scan` + `context`). Los subcomandos `save` y `search` llegan en la Fase 2.
+
+## ¿Por qué Brain?
+
+Las skills son metodología. CLAUDE.md / AGENTS.md / GEMINI.md son reglas estables. Pero todos los proyectos tienen *conocimiento histórico cambiante*:
+
+- "Usamos Koin, no Hilt — decisión de marzo 2026, sigue activa."
+- "FirebaseAuth iOS necesita mantener `composeApp` en minúsculas hasta el próximo major de CocoaPods. Es temporal."
+- "El test de DataStore tiene que esperar `dataStore.data.first { it.asMap().isEmpty() }` después de `clear`."
+
+Eso no entra cómodo en CLAUDE.md (no es regla estable) ni en una skill (no es metodología). Entra en el Brain.
+
+## Filosofía
+
+- **Por proyecto**, no global. Cada repo mobile tiene su propio cerebro local en `<repo>/.mobiai/brain/`.
+- **Local primero**. Markdown plano, JSON simple. Sin SQLite, embeddings ni nube por ahora.
+- **Mobile-first**. El valor diferencial es entender Android / iOS / KMP / Flutter / React Native, no guardar texto genérico.
+- **Sin secretos**. El scanner detecta archivos sensibles (`.env`, `GoogleService-Info.plist`, `google-services.json`) y solo registra su existencia, nunca su contenido.
+
+## Comandos disponibles
+
+```bash
+mobiai brain init      # Crea .mobiai/brain/ en el proyecto actual (idempotente)
+mobiai brain scan      # Detecta stack: Android, iOS, KMP, Flutter, RN, librerías, CI/CD
+mobiai brain context   # Imprime Markdown con config + scan + memorias
+```
+
+Todos aceptan `--root <ruta>` para apuntar a un proyecto distinto del directorio actual.
+
+### `mobiai brain init`
+
+Crea la estructura local:
+
+```
+<repo>/.mobiai/brain/
+├── config.json
+└── memories/
+    ├── decisions.md
+    ├── bugfixes.md
+    ├── testing.md
+    ├── integrations.md
+    └── releases.md
+```
+
+Es idempotente: si `config.json` o cualquier `memories/*.md` ya existe, no se sobrescribe.
+
+Para localizar la raíz del proyecto, sube por los ancestros del cwd buscando, en este orden de prioridad:
+
+1. `.mobiai/brain/config.json` (un brain ya inicializado).
+2. `.git/`.
+3. `settings.gradle.kts` / `settings.gradle` (Android / KMP).
+4. `pubspec.yaml` (Flutter).
+5. `Package.swift`.
+6. `*.xcworkspace` / `*.xcodeproj`.
+7. `Podfile`.
+8. `package.json` con dependencia `react-native`.
+
+Si nada coincide, usa el directorio actual y avisa con un warning.
+
+### `mobiai brain scan`
+
+Recorre el árbol del proyecto (profundidad máx. 6, ignorando `.git`, `node_modules`, `build`, `Pods`, `DerivedData`, `.dart_tool`, etc.) y produce `.mobiai/brain/scan.json` con:
+
+- `project_type`: `android` | `ios` | `kmp` | `flutter` | `react_native` | `unknown`.
+- `platforms`: `android`, `ios`, `shared` (lo que se haya detectado).
+- `build_systems`: `gradle`, `cocoapods`, `spm`, `npm`.
+- `ui` / `di` / `network` / `persistence` / `serialization`: librerías reconocidas (Compose, SwiftUI, Koin, Hilt, Ktor, Retrofit, Room, DataStore, kotlinx.serialization, ...).
+- `testing`: JUnit, MockK, Mockito, Turbine, Espresso, ...
+- `integrations`: Firebase y otras integraciones detectables por strings en `build.gradle.kts` / `Podfile` / `package.json`.
+- `ci_cd`: GitHub Actions, Bitrise, Codemagic, Fastlane.
+- `warnings`: archivos sensibles detectados (sin leer su contenido).
+
+`scan` requiere haber corrido `init` antes.
+
+### `mobiai brain context`
+
+Lee `config.json`, `scan.json` (si existe) y todas las memorias. Imprime un Markdown listo para agentes:
+
+```
+# MobiAI Brain Context
+
+Project: taykus-kmp
+Type: Kotlin Multiplatform
+Platforms: android, ios, shared
+
+## Detected Stack
+- UI: compose_multiplatform
+- DI: koin
+- Network: ktor
+- Build systems: gradle
+
+## Project Rules
+- Prioritize clean architecture
+- ...
+
+## Architecture Decisions
+...
+
+## Known Bugfixes
+...
+
+## Testing Patterns
+...
+
+## Integrations
+...
+
+## Release Notes
+...
+
+## Warnings
+- archivo sensible detectado: .env (no leído)
+```
+
+## Diferencia frente a otros conceptos
+
+| | Skills | CLAUDE.md / AGENTS.md / GEMINI.md | MobiAI Brain |
+|---|---|---|---|
+| **Qué guarda** | Metodología, buenas prácticas | Reglas estables del proyecto | Conocimiento histórico cambiante |
+| **Alcance** | Global (compartido entre proyectos) | Por proyecto | Por proyecto |
+| **Estructura** | SKILL.md | Markdown libre | Markdown estructurado + JSON |
+| **Caduca?** | No (se actualiza vía PR) | Pocas veces | A menudo (workarounds temporales, decisiones revisables) |
+
+## Roadmap
+
+**Fase 1 (este PR)** — `init`, `scan`, `context`.
+
+**Fase 2** — `save decision|bugfix|testing|integration|release`, `search`, flags `--section` / `--platform` en `context`.
+
+**Fase 3** — MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente.
+
+**Fase futura** — migración a SQLite + FTS5 si Markdown se queda corto.

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -24,9 +24,13 @@ Eso no entra cómodo en CLAUDE.md (no es regla estable) ni en una skill (no es m
 ## Comandos disponibles
 
 ```bash
-mobiai brain init      # Crea .mobiai/brain/ en el proyecto actual (idempotente)
-mobiai brain scan      # Detecta stack: Android, iOS, KMP, Flutter, RN, librerías, CI/CD
-mobiai brain context   # Imprime Markdown con config + scan + memorias
+mobiai brain init                  # Crea .mobiai/brain/ en el proyecto actual (idempotente)
+mobiai brain scan                  # Detecta stack: Android, iOS, KMP, Flutter, RN, librerías, CI/CD
+mobiai brain context               # Imprime Markdown con config + scan + memorias
+
+mobiai brain save decision ...     # Guarda una decisión de arquitectura
+mobiai brain save bugfix ...       # Guarda un bugfix o workaround
+mobiai brain save testing ...      # Guarda un patrón de testing reusable
 ```
 
 Todos aceptan `--root <ruta>` para apuntar a un proyecto distinto del directorio actual.
@@ -75,6 +79,45 @@ Recorre el árbol del proyecto (profundidad máx. 6, ignorando `.git`, `node_mod
 - `warnings`: archivos sensibles detectados (sin leer su contenido).
 
 `scan` requiere haber corrido `init` antes.
+
+### `mobiai brain save <type>`
+
+Tres subcomandos: `decision`, `bugfix`, `testing`. Todos comparten los mismos flags:
+
+| Flag | ¿Requerido? | Notas |
+|---|---|---|
+| `--title <str>` | sí | Título corto, se usa como heading H2 |
+| `--platform <plat>` | no | `android` \| `ios` \| `shared` \| `kmp` \| `flutter` \| `react-native` |
+| `--area <str>` | no | Libre (`firebase_auth`, `dependency_injection`, `datastore`, ...) |
+| `--status <s>` | no | `active` (default) \| `temporary` \| `deprecated` |
+| `--review-after YYYY-MM-DD` | no | Sentido sobre todo en `temporary` |
+| `--files a,b,c` | no | Lista de paths relevantes |
+| `--body <md>` | no | Cuerpo Markdown. Si se omite, lee de stdin (útil para pipear contenido multilínea). |
+
+Ejemplo:
+
+```bash
+mobiai brain save decision \
+  --title "Use Koin como DI" \
+  --platform shared \
+  --area dependency_injection \
+  --files "composeApp/src/commonMain/di/Module.kt" \
+  --body "### Decision
+Usar Koin como framework de DI para todo el código compartido.
+
+### Reason
+KMP-friendly, sin code generation, ya integrado con composeApp/iosApp."
+```
+
+**Guard**: si no existe `.mobiai/brain/config.json` el comando falla con un error claro y exit code 1. No crea el brain solo — sugiere correr `mobiai brain init` primero.
+
+El tipo interno (`type:` en la entrada renderizada) se deriva del subcomando + status:
+- `decision` → `architecture_decision`
+- `bugfix` + `temporary` → `platform_workaround`
+- `bugfix` + `active`/`deprecated` → `bug_fix`
+- `testing` → `testing_pattern`
+
+Cada entrada recibe un `id` estable basado en el slug del título + timestamp UTC, así dos saves con el mismo título no colisionan.
 
 ### `mobiai brain context`
 
@@ -125,12 +168,20 @@ Platforms: android, ios, shared
 | **Estructura** | SKILL.md | Markdown libre | Markdown estructurado + JSON |
 | **Caduca?** | No (se actualiza vía PR) | Pocas veces | A menudo (workarounds temporales, decisiones revisables) |
 
+## Integración con skills
+
+`mobiai-fix-issue` propone guardar el bugfix automáticamente al final de Phase 6 (verification), pero **solo si** el proyecto ya tiene un brain inicializado. Si no, el hook se salta sin ruido. Otras skills (write-tests, mobile-debugging, etc.) seguirán el mismo patrón a medida que se vayan integrando.
+
 ## Roadmap
 
-**Fase 1 (este PR)** — `init`, `scan`, `context`.
+**Fase 1** — `init`, `scan`, `context`. ✓
+**Fase 2 (este PR)** — `save decision|bugfix|testing` + hook en `mobiai-fix-issue`. ✓
 
-**Fase 2** — `save decision|bugfix|testing|integration|release`, `search`, flags `--section` / `--platform` en `context`.
-
-**Fase 3** — MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente.
+**Próximos pasos**:
+- `save integration` y `save release` (categorías de menor volumen).
+- `search <query>` con grep simple sobre los `.md`.
+- Flags `--section` / `--platform` en `context`.
+- Auto-save desde más skills (`mobiai-write-tests` → testing pattern, `mobiai-mobile-debugging` → bugfix).
+- MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente.
 
 **Fase futura** — migración a SQLite + FTS5 si Markdown se queda corto.

--- a/plugins/core/skills/mobiai-brain/SKILL.md
+++ b/plugins/core/skills/mobiai-brain/SKILL.md
@@ -19,15 +19,41 @@ Per-project living memory for mobile projects. Lives at `<repo>/.mobiai/brain/` 
 
 If the project has no `.mobiai/brain/` yet and the user wants project memory, suggest running `mobiai brain init`. Don't run it yourself unless asked.
 
-## Phase 1 commands available today
+## Commands available today
 
 ```
-mobiai brain init      # Create .mobiai/brain/ in the current project (idempotent)
-mobiai brain scan      # Detect stack: Android / iOS / KMP / Flutter / RN + libraries
-mobiai brain context   # Print Markdown context: config + scan + memories
+mobiai brain init                  # Create .mobiai/brain/ in the project (idempotent)
+mobiai brain scan                  # Detect stack: Android / iOS / KMP / Flutter / RN + libs
+mobiai brain context               # Print Markdown context: config + scan + memories
+
+mobiai brain save decision         # Append an architecture decision
+mobiai brain save bugfix           # Append a bugfix or workaround
+mobiai brain save testing          # Append a reusable testing pattern
 ```
 
-`save` and `search` subcommands are coming in Phase 2. Until then, the user (or you, with their consent) appends entries to `.mobiai/brain/memories/*.md` by hand.
+`search` is still coming in a future phase — for now use `mobiai brain context` (or grep over `.mobiai/brain/memories/*.md` directly) to retrieve.
+
+### `save` flags
+
+All three save subcommands share the same flags:
+
+| Flag | Required? | Notes |
+|---|---|---|
+| `--title <str>` | yes | Short descriptive title (becomes the H2 heading) |
+| `--platform <plat>` | no | `android` \| `ios` \| `shared` \| `kmp` \| `flutter` \| `react-native` |
+| `--area <str>` | no | Free-form (e.g. `firebase_auth`, `dependency_injection`, `datastore`) |
+| `--status <s>` | no | `active` (default) \| `temporary` \| `deprecated` |
+| `--review-after YYYY-MM-DD` | no | Mostly meaningful for `temporary` status |
+| `--files a,b,c` | no | Comma-separated repo-relative paths the entry refers to |
+| `--body <md>` | no | Markdown body. If omitted, the command reads stdin (handy for piping multi-line content) |
+
+**Type label mapping** (visible in the rendered entry):
+- `decision` → `architecture_decision`
+- `bugfix` + `temporary` → `platform_workaround`
+- `bugfix` + `active`/`deprecated` → `bug_fix`
+- `testing` → `testing_pattern`
+
+**Guard**: every `save` errors out if `.mobiai/brain/config.json` is missing. The CLI does NOT auto-init the brain — it suggests `mobiai brain init` and exits non-zero. When invoking from another skill, check the file first and skip silently if absent.
 
 ## Recommended flow
 

--- a/plugins/core/skills/mobiai-brain/SKILL.md
+++ b/plugins/core/skills/mobiai-brain/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: mobiai-brain
+description: "Use when the user asks about past decisions, workarounds, bugfixes, testing patterns or integrations specific to *this* project, OR before proposing non-trivial architecture/integration changes. MobiAI Brain is per-project living memory at <repo>/.mobiai/brain/. Loads context the user already captured so suggestions respect real project conventions instead of generic best practices."
+license: MIT
+compatibility: [claude-code, cursor, copilot, codex, gemini]
+platforms: [android, ios, kmp, flutter, react-native]
+---
+
+# MobiAI Brain
+
+Per-project living memory for mobile projects. Lives at `<repo>/.mobiai/brain/` — separate from MobiAI's global state in `~/.mobiai/`. Each project has its own brain; nothing is shared between projects.
+
+## When to invoke this skill
+
+- User asks "what did we decide about X?" / "why is Y like that in this project?" / "is this workaround still needed?"
+- You are about to propose changes to architecture, dependency injection, networking, persistence, testing strategy, or third-party integrations.
+- User mentions an integration that often has project-specific quirks (Firebase, push, payments, auth).
+- User starts a fresh session in a mobile project and you need quick orientation.
+
+If the project has no `.mobiai/brain/` yet and the user wants project memory, suggest running `mobiai brain init`. Don't run it yourself unless asked.
+
+## Phase 1 commands available today
+
+```
+mobiai brain init      # Create .mobiai/brain/ in the current project (idempotent)
+mobiai brain scan      # Detect stack: Android / iOS / KMP / Flutter / RN + libraries
+mobiai brain context   # Print Markdown context: config + scan + memories
+```
+
+`save` and `search` subcommands are coming in Phase 2. Until then, the user (or you, with their consent) appends entries to `.mobiai/brain/memories/*.md` by hand.
+
+## Recommended flow
+
+1. **Read context first.** Before proposing arch/integration/testing changes, run `mobiai brain context` (or read `.mobiai/brain/memories/*.md` directly) and respect what's there.
+2. **Honor `status: active` decisions.** Treat them as project rules.
+3. **Treat `status: temporary` workarounds as provisional.** They are not permanent decisions; do not promote them to `CLAUDE.md`.
+4. **Don't conflate Brain with CLAUDE.md.**
+   - `CLAUDE.md` holds *stable* rules: architecture, commands, conventions.
+   - Brain holds *historical and changing knowledge*: decisions with dates, bugfixes, workarounds with review dates, testing patterns discovered along the way.
+5. **Don't conflate Brain with skills.**
+   - Skills teach the agent *how* to work (methodology).
+   - Brain stores *what* the project actually did and decided.
+6. **Never store secrets.** The scanner already flags sensitive files (`.env`, `GoogleService-Info.plist`, `google-services.json`) and refuses to read their contents. If you're about to write a memory, do the same: paths and behavior, not credentials.
+
+## What the Brain looks like on disk
+
+```
+<repo>/.mobiai/brain/
+├── config.json           # version, project_name, project_type, platforms, rules
+├── scan.json             # last scan: stack, integrations, CI/CD, warnings
+└── memories/
+    ├── decisions.md
+    ├── bugfixes.md
+    ├── testing.md
+    ├── integrations.md
+    └── releases.md
+```
+
+Memory entries are Markdown sections. Recommended shape (also what Phase 2 `save` will produce):
+
+```
+## <Title>
+
+- id: <slug>
+- type: architecture_decision | platform_workaround | testing_pattern | integration_note
+- status: active | temporary | deprecated
+- platform: android | ios | shared | flutter | react-native
+- area: <free-form>
+- date: <ISO date>
+- review_after: <ISO date>   (optional, for temporary entries)
+
+### Decision / Problem / Pattern
+...
+
+### Reason / Root Cause / Solution
+...
+
+### Files
+- path/to/file
+```
+
+## Behavior contract
+
+- Brain is **per-project**. Don't mix decisions from different repos.
+- Brain is **complementary** to `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`, not a replacement.
+- The agent **must not** silently overwrite a memory entry. Append; if changing status, leave a note explaining why.
+- If the scan in `scan.json` is older than the user's last large refactor, suggest re-running `mobiai brain scan` before relying on it.

--- a/plugins/core/skills/mobiai-fix-issue/SKILL.md
+++ b/plugins/core/skills/mobiai-fix-issue/SKILL.md
@@ -176,6 +176,32 @@ Platform-specific compile and test commands (handled by `mobiai-mobile-verificat
 
 If verification fails, do not rationalize. Return to Phase 3 with the new evidence.
 
+### Optional: capture in MobiAI Brain
+
+After verification passes, check whether `<repo>/.mobiai/brain/config.json` exists. If it does NOT, skip this step silently — not every project uses Brain.
+
+If it does, **propose** saving this fix as a brain `bugfix` entry to the user. Get one-line approval before running save — never invoke it silently. Use status `temporary` (with `--review-after` ~2-3 months out) for workarounds that should be revisited; use `active` for real fixes that should stick.
+
+```bash
+mobiai brain save bugfix \
+  --title "<short description, e.g. 'FirebaseAuth iOS module renaming'>" \
+  --platform <android|ios|shared|kmp|flutter|react-native> \
+  --area <free-form, e.g. firebase_auth> \
+  --status <active|temporary> \
+  --review-after <YYYY-MM-DD if temporary> \
+  --files "<file1>,<file2>" \
+  --body "### Problem
+...
+
+### Root Cause
+...
+
+### Solution
+..."
+```
+
+The save is the same content the agent already produced for the PR description (Phase 7) — just structured for future retrieval. If the project tracks `.mobiai/brain/memories/` in git, the new entry will be staged with the rest of the fix in Phase 7.
+
 ## Phase 7: Open the PR — FINAL GATE (always)
 
 **Invoke skill `mobiai-create-pr`**. This is the non-negotiable gate for every ticket regardless of path — before pushing, the user will see the full diff plus the context below and must explicitly approve.

--- a/plugins/core/skills/using-mobiai/SKILL.md
+++ b/plugins/core/skills/using-mobiai/SKILL.md
@@ -75,6 +75,7 @@ Match the user's intent against the rows below. If any row matches even at 1% co
 | Starting feature work in isolation | `mobiai-mobile-worktrees` |
 | Implementation done, need to integrate | `mobiai-mobile-finishing-branch` |
 | Creating a new MobiAI skill | `mobiai-writing-skills` |
+| User asks about project decisions, bugfixes, workarounds, or "what did we decide last time" | `mobiai-brain` |
 
 If the request doesn't match any row, ask the user to clarify before touching code. Do not improvise a workflow.
 


### PR DESCRIPTION
## Summary

Adds `mobiai brain` — a per-project living memory layer for mobile agents. Three subcommands ship in this PR: `init`, `scan`, `context`. Memory lives at `<repo>/.mobiai/brain/`, separated from the global CLI state in `~/.mobiai/`.

- **Why**: Skills teach agents *how* to work; `CLAUDE.md` holds stable rules. Neither covers the *historical and changing* knowledge of a project — decisions, bugfixes, temporary workarounds, project-specific testing patterns, integration quirks. That's what Brain is for.
- **Scope**: Phase 1 only (`init` / `scan` / `context`). `save` and `search` come in Phase 2; SQLite, embeddings, MCP and cloud are explicitly out of scope.

## Why each change

- **New `cli/internal/brain/` package** (paths, config, scan, scanner, 5 platform detectors, deps detector, context builder, memory templates) — keeps the Brain logic pure (no cobra deps) so it can be reused later from MCP tools or other subcommands. Mirrors how `internal/state` and `internal/catalog` are structured.
- **New `cli/internal/cmd/brain.go`** — thin cobra glue calcado del patrón de `skills.go` (parent + subcomandos `init`/`scan`/`context`). Mensajes en español para match con el resto del CLI.
- **`cli/cmd/mobiai/main.go`** — registra `NewBrainCmd()` junto al resto de comandos.
- **`plugins/core/skills/mobiai-brain/SKILL.md`** — enseña a los agentes cuándo invocar Brain (preguntas sobre decisiones pasadas, antes de cambios de arquitectura/integración) y aclara la diferencia con CLAUDE.md y con skills.
- **`plugins/core/skills/using-mobiai/SKILL.md`** — añade una fila a la Quick Decision Guide para que el routing detecte intent del usuario sobre memoria del proyecto.
- **`docs/brain.md` y sección preview en `README.md`** — documentación mínima de la feature.

### Decisiones de diseño

- **Project-root detection** sube ancestros buscando, en este orden: `.mobiai/brain/config.json` (existente) > `.git` > `settings.gradle(.kts)` > `pubspec.yaml` > `Package.swift` > `*.xcworkspace`/`*.xcodeproj` > `Podfile` > `package.json` con `react-native`. Si nada matchea, usa cwd con warning.
- **Scanner** capeado a profundidad 6, skip de `node_modules`, `Pods`, `DerivedData`, `build`, `.gradle`, `.dart_tool`, `.swiftpm`, `.git`, `.idea`, `.kotlin`, `out`, `target`, `vendor`, `.mobiai`. Solo lee archivos en allowlist (build.gradle{,.kts}, settings.gradle{,.kts}, pubspec.yaml, package.json, Podfile, Package.swift, AndroidManifest.xml, libs.versions.toml). Cualquier otro archivo se registra por path, no por contenido.
- **Idempotencia**: `init` nunca sobrescribe `config.json` ni `memories/*.md` existentes. `scan` sí sobrescribe `scan.json` (es la foto actual). Escrituras JSON con temp+rename atómico, mismo patrón que `state/installed.go`.
- **Sin secretos**: archivos sensibles (`.env`, `GoogleService-Info.plist`, `google-services.json`) aparecen como warnings pero nunca se abren — hay un test (`TestScan_FlagsSensitiveFilesWithoutReading`) que verifica que su contenido no entra en el output.
- **Precedencia de `project_type`**: KMP > Flutter > RN > Android > iOS. KMP gana sobre Android porque suele *contener* un módulo Android; Flutter/RN ganan sobre sus plataformas host por la misma razón.
- **Naming files**: los detectores se llaman `detect_<plat>_platform.go` para evitar el build constraint implícito de Go por sufijo `_GOOS.go` (que excluiría `detect_android.go` y `detect_ios.go` de builds que no son android/ios).

## Platform

- **Affected platform**: ninguna específica — la feature es de la herramienta CLI (`MobiAI-Core`), no de un proyecto mobile.
- **Min Go**: igual que el resto del CLI (`go 1.25.0` en `go.mod`; verificado con Go 1.26.3).
- **New permissions or entitlements**: ninguno.

## Changes

- `cli/cmd/mobiai/main.go` — registra `cmd.NewBrainCmd()`.
- `cli/internal/brain/paths.go` — `BrainPaths`, `FindProjectRoot`.
- `cli/internal/brain/config.go` — `Config`, `LoadConfig`/`Save`, `writeJSONAtomic` (atomic temp+rename).
- `cli/internal/brain/scan.go` — `Scan` struct, `LoadScan`/`Save`, project-type y platform constants.
- `cli/internal/brain/scanner.go` — `ScanProject(root)`: walk + index + detectores + dedup.
- `cli/internal/brain/detect_android_platform.go`, `detect_kmp_platform.go`, `detect_flutter_platform.go`, `detect_ios_platform.go`, `detect_reactnative_platform.go` — un detector por plataforma.
- `cli/internal/brain/detect_deps.go` — tabla de matchers para UI / DI / network / persistence / serialization / testing / integraciones, más detectores de CI/CD y archivos sensibles.
- `cli/internal/brain/memory.go` — templates iniciales para `decisions.md`, `bugfixes.md`, `testing.md`, `integrations.md`, `releases.md`. `EnsureMemoryFiles` idempotente.
- `cli/internal/brain/context.go` — `BuildContext(cfg, scan, paths)` arma el Markdown final.
- `cli/internal/cmd/brain.go` — cobra padre + 3 subcomandos, flag `--root`.
- Tests: `paths_test.go` (table-driven con 9 casos de FindProjectRoot), `scanner_test.go` (Android, KMP, Flutter, iOS, RN, CI/CD, secretos, dirs ruidosos, vacío), `context_test.go` (full output + sin scan + idempotencia de memorias), `cmd/brain_test.go` (integración end-to-end de init → scan → context).
- `docs/brain.md` — doc de la feature.
- `README.md` — sección preview con los 3 comandos.
- `plugins/core/skills/mobiai-brain/SKILL.md` — skill nueva.
- `plugins/core/skills/using-mobiai/SKILL.md` — fila adicional en la Quick Decision Guide.

## Test Plan

- [x] `go build ./...` limpio
- [x] `go test ./...` todo verde — incluye los nuevos tests de `internal/brain` y `internal/cmd`
- [x] Smoke manual contra un árbol KMP fake en `/tmp`:
  - [x] `brain init` crea `.mobiai/brain/` con `config.json` + 5 memorias
  - [x] `brain scan` detecta `project_type: kmp`, plataformas android/ios/shared, UI compose_multiplatform, DI koin, network ktor
  - [x] `brain context` imprime Markdown con todas las secciones
  - [x] Segundo `brain init` no sobrescribe nada
  - [x] `.env` aparece en warnings sin que su contenido llegue al output
- [x] CLI existente intacta: `mobiai status`, `mobiai skills list`, `mobiai --help` siguen funcionando; `brain` aparece en el help

## Regression Risk

- [ ] Toca lifecycle de Activity/Fragment o ViewController — N/A
- [ ] Toca threading / coroutines / Dispatchers / GCD — N/A
- [ ] Toca navegación o deep links — N/A
- [ ] Modifica ProGuard/R8 o build settings de iOS — N/A
- [ ] Cambia versiones de dependencias — N/A (no se agregan deps a `go.mod`)
- **Risk notes**: cambio aditivo. La única modificación a código existente es 1 línea en `cli/cmd/mobiai/main.go` para registrar el nuevo comando, y 1 fila en `using-mobiai/SKILL.md`. No toca código de los comandos existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)