### PR TITLE
feat(brain): brain search + filtros en brain context

### DIFF
--- a/cli/internal/brain/context.go
+++ b/cli/internal/brain/context.go
@@ -2,6 +2,7 @@ package brain
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -26,41 +27,120 @@ func projectTypeLabel(t string) string {
 	}
 }
 
+// stackSection is the canonical name for the auto-detected stack block.
+// Not a memory section, but addressable via --section like the rest.
+const (
+	stackSection    = "stack"
+	rulesSection    = "rules"
+	warningsSection = "warnings"
+)
+
+// ContextOptions tweaks the output of BuildContext. Zero value renders
+// everything (current behavior — back-compat with the original signature
+// via BuildContext).
+type ContextOptions struct {
+	// Sections is the canonical list of sections to render, in order.
+	// Empty = render all (stack, rules, memories…, warnings).
+	Sections []string
+	// Filter is applied to every memory entry. Stack/rules/warnings
+	// ignore the filter (those aren't entry-shaped).
+	Filter EntryFilter
+}
+
 // BuildContext assembles the Markdown context document consumed by AI
-// agents. It is intentionally close to the spec layout — section names
-// and order matter because skills/agents grep for them.
+// agents with no filters or section restriction — the original entry
+// point, preserved for callers that want everything.
 func BuildContext(cfg Config, scan *Scan, p BrainPaths) string {
+	return BuildContextWith(cfg, scan, p, ContextOptions{})
+}
+
+// BuildContextWith renders the Markdown context using opts. Section
+// names and order match the spec because skills/agents grep for them.
+func BuildContextWith(cfg Config, scan *Scan, p BrainPaths, opts ContextOptions) string {
+	groups, err := ParseAllMemories(p)
+	if err != nil {
+		// Parser errors are unexpected (files are normal Markdown);
+		// fall back to an empty groups map so the document still renders.
+		groups = map[string][]MemoryEntry{}
+	}
+
+	include := includeMap(opts.Sections)
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "# MobiAI Brain Context\n\n")
-	fmt.Fprintf(&b, "Project: %s\n", cfg.ProjectName)
-	fmt.Fprintf(&b, "Type: %s\n", projectTypeLabel(cfg.ProjectType))
+	writeHeader(&b, cfg, scan)
+
+	for _, section := range renderOrder() {
+		if include != nil {
+			if _, ok := include[section]; !ok {
+				continue
+			}
+		}
+		switch section {
+		case stackSection:
+			writeStackSection(&b, scan)
+		case rulesSection:
+			writeRulesSection(&b, cfg)
+		case warningsSection:
+			writeWarningsSection(&b, scan)
+		default: // memory section
+			entries := groups[section]
+			if !opts.Filter.Empty() {
+				entries = FilterEntries(entries, opts.Filter)
+			}
+			writeMemorySection(&b, section, entries, !opts.Filter.Empty())
+		}
+	}
+	return b.String()
+}
+
+// renderOrder returns the canonical section sequence for the context
+// document: stack, rules, then each memory section in MemoryFiles
+// order, then warnings.
+func renderOrder() []string {
+	out := []string{stackSection, rulesSection}
+	for _, mf := range MemoryFiles {
+		out = append(out, canonicalSection(mf.Name))
+	}
+	out = append(out, warningsSection)
+	return out
+}
+
+// includeMap returns a lookup set of requested sections, normalized to
+// lowercase trimmed. Returns nil when the request is empty (= render
+// all) so callers can short-circuit the `_, ok :=` check.
+func includeMap(sections []string) map[string]struct{} {
+	if len(sections) == 0 {
+		return nil
+	}
+	m := map[string]struct{}{}
+	for _, s := range sections {
+		key := strings.ToLower(strings.TrimSpace(s))
+		if key == "" {
+			continue
+		}
+		m[key] = struct{}{}
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+func writeHeader(b *strings.Builder, cfg Config, scan *Scan) {
+	fmt.Fprintf(b, "# MobiAI Brain Context\n\n")
+	fmt.Fprintf(b, "Project: %s\n", cfg.ProjectName)
+	fmt.Fprintf(b, "Type: %s\n", projectTypeLabel(cfg.ProjectType))
 	if scan != nil && cfg.ProjectType == ProjectTypeUnknown && scan.ProjectType != ProjectTypeUnknown {
-		// scan has a fresher answer than config — show both so the user
-		// notices the drift. To refresh config, re-run `mobiai brain
-		// scan` (which auto-fills project_type/platforms when they're
-		// at defaults) or edit config.json by hand. `brain init` is
-		// idempotent and will NOT overwrite the existing config.
-		fmt.Fprintf(&b, "Type (scan): %s\n", projectTypeLabel(scan.ProjectType))
+		fmt.Fprintf(b, "Type (scan): %s\n", projectTypeLabel(scan.ProjectType))
 	}
 	platforms := cfg.Platforms
 	if len(platforms) == 0 && scan != nil {
 		platforms = scan.Platforms
 	}
 	if len(platforms) > 0 {
-		fmt.Fprintf(&b, "Platforms: %s\n", strings.Join(platforms, ", "))
+		fmt.Fprintf(b, "Platforms: %s\n", strings.Join(platforms, ", "))
 	}
 	b.WriteString("\n")
-
-	writeStackSection(&b, scan)
-	writeRulesSection(&b, cfg)
-
-	for _, mf := range MemoryFiles {
-		writeMemorySection(&b, p, mf)
-	}
-
-	writeWarningsSection(&b, scan)
-	return b.String()
 }
 
 func writeStackSection(b *strings.Builder, scan *Scan) {
@@ -108,50 +188,78 @@ func writeRulesSection(b *strings.Builder, cfg Config) {
 	b.WriteString("\n")
 }
 
-func writeMemorySection(b *strings.Builder, p BrainPaths, mf MemoryFile) {
-	body := readMemory(p, mf.Name)
-	body = stripLeadingTitle(body)
-	body = stripHTMLComments(body)
-	body = strings.TrimSpace(body)
-
-	fmt.Fprintf(b, "%s\n\n", mf.ContextHead)
-	if body == "" {
-		b.WriteString("_No entries yet._\n\n")
+// writeMemorySection renders a memory section from parsed entries.
+// `filtered` distinguishes "no entries exist" from "filter dropped them
+// all" so the empty-state message is accurate.
+func writeMemorySection(b *strings.Builder, section string, entries []MemoryEntry, filtered bool) {
+	heading := memoryHeading(section)
+	fmt.Fprintf(b, "%s\n\n", heading)
+	if len(entries) == 0 {
+		if filtered {
+			b.WriteString("_No entries match the current filter._\n\n")
+		} else {
+			b.WriteString("_No entries yet._\n\n")
+		}
 		return
 	}
-	b.WriteString(body)
-	b.WriteString("\n\n")
+	for i, e := range entries {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		writeEntry(b, e)
+	}
+	b.WriteString("\n")
 }
 
-// stripLeadingTitle drops the first `# ...` line if the file starts with
-// one — the section heading printed by BuildContext already covers it.
-func stripLeadingTitle(content string) string {
-	trimmed := strings.TrimLeft(content, "\n")
-	if !strings.HasPrefix(trimmed, "# ") {
-		return content
+// writeEntry serializes one MemoryEntry back to its canonical Markdown
+// shape — same layout that `save` writes, so context output is
+// round-tripable through the parser.
+func writeEntry(b *strings.Builder, e MemoryEntry) {
+	fmt.Fprintf(b, "## %s\n\n", e.Title)
+	for _, k := range metaOrder(e.Meta) {
+		fmt.Fprintf(b, "- %s: %s\n", k, e.Meta[k])
 	}
-	if idx := strings.Index(trimmed, "\n"); idx >= 0 {
-		return trimmed[idx+1:]
+	body := strings.TrimSpace(e.Body)
+	if body != "" {
+		b.WriteString("\n")
+		b.WriteString(body)
+		b.WriteString("\n")
 	}
-	return ""
 }
 
-// stripHTMLComments removes every `<!-- ... -->` block from content.
-// Used to drop the init-time placeholders before printing a section
-// (they're meant for whoever opens the .md, not for the context dump).
-func stripHTMLComments(content string) string {
-	for {
-		start := strings.Index(content, "<!--")
-		if start < 0 {
-			return content
+// metaOrder returns the metadata keys in the canonical order used by
+// `save`. Unknown keys are appended sorted at the end so user-added
+// fields render deterministically.
+func metaOrder(m map[string]string) []string {
+	canonical := []string{"id", "type", "status", "platform", "area", "date", "review_after"}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(m))
+	for _, k := range canonical {
+		if _, ok := m[k]; ok {
+			out = append(out, k)
+			seen[k] = true
 		}
-		rest := content[start:]
-		end := strings.Index(rest, "-->")
-		if end < 0 {
-			return content
-		}
-		content = content[:start] + content[start+end+3:]
 	}
+	extras := make([]string, 0)
+	for k := range m {
+		if !seen[k] {
+			extras = append(extras, k)
+		}
+	}
+	sort.Strings(extras)
+	out = append(out, extras...)
+	return out
+}
+
+// memoryHeading maps a canonical section name to its display heading.
+// Falls back to a Title-Case version for unknown sections.
+func memoryHeading(section string) string {
+	for _, mf := range MemoryFiles {
+		if canonicalSection(mf.Name) == section {
+			return mf.ContextHead
+		}
+	}
+	return "## " + strings.Title(section)
 }
 
 func writeWarningsSection(b *strings.Builder, scan *Scan) {

--- a/cli/internal/brain/filter.go
+++ b/cli/internal/brain/filter.go
@@ -1,0 +1,66 @@
+package brain
+
+import "strings"
+
+// EntryFilter narrows the set of MemoryEntry values that will be
+// rendered or searched. Semantics are AND across non-empty fields:
+// every condition must pass for the entry to match. Empty fields are
+// no-ops (don't restrict).
+//
+// String comparisons are case-insensitive and trimmed.
+type EntryFilter struct {
+	Platform string // matches the `platform:` meta field
+	Status   string // matches the `status:` meta field
+	Area     string // matches the `area:` meta field (substring)
+	Query    string // free-text, matches Title or Body (substring)
+}
+
+// Empty reports whether the filter would let everything through.
+func (f EntryFilter) Empty() bool {
+	return f.Platform == "" && f.Status == "" && f.Area == "" && f.Query == ""
+}
+
+// Matches reports whether e satisfies every set condition.
+func (f EntryFilter) Matches(e MemoryEntry) bool {
+	if f.Platform != "" && !eqFold(e.Get("platform"), f.Platform) {
+		return false
+	}
+	if f.Status != "" && !eqFold(e.Get("status"), f.Status) {
+		return false
+	}
+	if f.Area != "" && !containsFold(e.Get("area"), f.Area) {
+		return false
+	}
+	if f.Query != "" {
+		q := strings.ToLower(strings.TrimSpace(f.Query))
+		if !strings.Contains(strings.ToLower(e.Title), q) &&
+			!strings.Contains(strings.ToLower(e.Body), q) {
+			return false
+		}
+	}
+	return true
+}
+
+// FilterEntries returns the subset of in for which f.Matches is true.
+// Returns a non-nil empty slice when nothing matches so callers can
+// distinguish "no entries to begin with" from "nothing matched".
+func FilterEntries(in []MemoryEntry, f EntryFilter) []MemoryEntry {
+	out := make([]MemoryEntry, 0, len(in))
+	for _, e := range in {
+		if f.Matches(e) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func eqFold(a, b string) bool {
+	return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
+}
+
+func containsFold(haystack, needle string) bool {
+	return strings.Contains(
+		strings.ToLower(strings.TrimSpace(haystack)),
+		strings.ToLower(strings.TrimSpace(needle)),
+	)
+}

--- a/cli/internal/brain/filter_test.go
+++ b/cli/internal/brain/filter_test.go
@@ -1,0 +1,105 @@
+package brain
+
+import "testing"
+
+func entry(meta map[string]string, title, body string) MemoryEntry {
+	return MemoryEntry{Title: title, Body: body, Meta: meta}
+}
+
+func TestEntryFilter_EmptyMatchesEverything(t *testing.T) {
+	f := EntryFilter{}
+	if !f.Empty() {
+		t.Error("zero filter should be empty")
+	}
+	if !f.Matches(entry(nil, "x", "y")) {
+		t.Error("empty filter should match any entry")
+	}
+}
+
+func TestEntryFilter_Platform(t *testing.T) {
+	e1 := entry(map[string]string{"platform": "ios"}, "a", "")
+	e2 := entry(map[string]string{"platform": "android"}, "b", "")
+	e3 := entry(map[string]string{"platform": "IOS"}, "c", "") // case-insensitive
+
+	f := EntryFilter{Platform: "ios"}
+	if !f.Matches(e1) || f.Matches(e2) || !f.Matches(e3) {
+		t.Errorf("platform filter wrong: e1=%v e2=%v e3=%v",
+			f.Matches(e1), f.Matches(e2), f.Matches(e3))
+	}
+}
+
+func TestEntryFilter_StatusExactMatch(t *testing.T) {
+	f := EntryFilter{Status: "temporary"}
+	// Status is an exact (fold) match — `active` must NOT pass when
+	// `temporary` is asked, even though they're both valid statuses.
+	if f.Matches(entry(map[string]string{"status": "active"}, "x", "")) {
+		t.Error("active should not match status=temporary")
+	}
+	if !f.Matches(entry(map[string]string{"status": "Temporary"}, "x", "")) {
+		t.Error("Temporary should match status=temporary (case-insensitive)")
+	}
+}
+
+func TestEntryFilter_AreaSubstring(t *testing.T) {
+	// Area uses substring match (folded) so `firebase` matches both
+	// `firebase_auth` and `Firebase Core`.
+	f := EntryFilter{Area: "firebase"}
+	for _, area := range []string{"firebase_auth", "Firebase Core", "firebase"} {
+		if !f.Matches(entry(map[string]string{"area": area}, "x", "")) {
+			t.Errorf("area %q should match `firebase`", area)
+		}
+	}
+	if f.Matches(entry(map[string]string{"area": "dependency_injection"}, "x", "")) {
+		t.Error("dependency_injection should not match firebase")
+	}
+}
+
+func TestEntryFilter_QueryMatchesTitleOrBody(t *testing.T) {
+	f := EntryFilter{Query: "koin"}
+	if !f.Matches(entry(nil, "Use Koin as DI", "")) {
+		t.Error("query should match title")
+	}
+	if !f.Matches(entry(nil, "DI choice", "we use Koin for KMP")) {
+		t.Error("query should match body")
+	}
+	if f.Matches(entry(nil, "Hilt setup", "Dagger Hilt config")) {
+		t.Error("entry without koin should not match")
+	}
+}
+
+func TestEntryFilter_AndSemantics(t *testing.T) {
+	f := EntryFilter{Platform: "ios", Status: "temporary"}
+	cases := []struct {
+		meta map[string]string
+		want bool
+	}{
+		{map[string]string{"platform": "ios", "status": "temporary"}, true},
+		{map[string]string{"platform": "ios", "status": "active"}, false},
+		{map[string]string{"platform": "android", "status": "temporary"}, false},
+	}
+	for _, c := range cases {
+		if got := f.Matches(entry(c.meta, "x", "")); got != c.want {
+			t.Errorf("meta=%v: got %v, want %v", c.meta, got, c.want)
+		}
+	}
+}
+
+func TestFilterEntries_DropsNonMatches(t *testing.T) {
+	in := []MemoryEntry{
+		entry(map[string]string{"platform": "ios"}, "a", ""),
+		entry(map[string]string{"platform": "android"}, "b", ""),
+		entry(map[string]string{"platform": "ios"}, "c", ""),
+	}
+	out := FilterEntries(in, EntryFilter{Platform: "ios"})
+	if len(out) != 2 || out[0].Title != "a" || out[1].Title != "c" {
+		t.Errorf("got %v", titles(out))
+	}
+}
+
+func titles(es []MemoryEntry) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.Title
+	}
+	return out
+}

--- a/cli/internal/brain/memory_parse.go
+++ b/cli/internal/brain/memory_parse.go
@@ -1,0 +1,180 @@
+package brain
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MemoryEntry is a parsed section of a memories/<file>.md file. The
+// parser reads the `## Title` heading, the `- key: value` metadata
+// bullets immediately after, and everything else up to the next `## `
+// (or EOF) as Body.
+//
+// This is the structured view of the Markdown that `save` writes — same
+// shape, parsed back. Used by `context` filtering and `search` so we
+// don't have to grep raw markdown.
+type MemoryEntry struct {
+	File  string            // basename, e.g. "decisions.md"
+	Title string            // H2 text (without the leading "## ")
+	Meta  map[string]string // id/type/status/platform/area/date/review_after/...
+	Body  string            // everything after metadata, before next entry
+}
+
+// Get returns the metadata value for key, or "" if missing.
+func (e MemoryEntry) Get(key string) string {
+	if e.Meta == nil {
+		return ""
+	}
+	return e.Meta[key]
+}
+
+// ParseMemoryFile reads path and returns each `## Title` block as a
+// MemoryEntry. Content before the first `## ` (file title, HTML
+// comments, intro prose) is ignored — those aren't entries.
+//
+// Returns ([], nil) if the file does not exist; the parser is permissive
+// about user edits, so an entry without metadata bullets is still
+// emitted with an empty Meta map.
+func ParseMemoryFile(path string) ([]MemoryEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("abrir %s: %w", path, err)
+	}
+	defer f.Close()
+
+	base := filepath.Base(path)
+	var entries []MemoryEntry
+	var current *MemoryEntry
+	// inMeta is true while we're still consuming the contiguous block
+	// of `- key: value` lines right after the title. The first non-meta
+	// line flips it to false and everything thereafter goes into Body.
+	inMeta := false
+	var body strings.Builder
+
+	flush := func() {
+		if current == nil {
+			return
+		}
+		current.Body = strings.TrimSpace(body.String())
+		entries = append(entries, *current)
+		current = nil
+		body.Reset()
+		inMeta = false
+	}
+
+	scanner := bufio.NewScanner(f)
+	// Allow generously large lines for big code blocks in entry bodies.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "## ") {
+			flush()
+			current = &MemoryEntry{
+				File:  base,
+				Title: strings.TrimSpace(strings.TrimPrefix(line, "## ")),
+				Meta:  map[string]string{},
+			}
+			inMeta = true
+			continue
+		}
+		if current == nil {
+			// Pre-first-entry content (file title, HTML comment header,
+			// intro prose). Discarded — only entries are interesting.
+			continue
+		}
+		if inMeta {
+			if k, v, ok := parseMetaLine(line); ok {
+				current.Meta[k] = v
+				continue
+			}
+			// Skip blank lines between title and the meta block — they
+			// don't end the meta region. The first non-blank, non-meta
+			// line does.
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			inMeta = false
+		}
+		body.WriteString(line)
+		body.WriteString("\n")
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("leer %s: %w", path, err)
+	}
+	flush()
+	return entries, nil
+}
+
+// parseMetaLine extracts (key, value, true) from a `- key: value` line.
+// Returns (_, _, false) for anything else (including non-bullet lines
+// or bullets without a colon).
+func parseMetaLine(line string) (string, string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "- ") {
+		return "", "", false
+	}
+	content := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+	colon := strings.Index(content, ":")
+	if colon <= 0 {
+		return "", "", false
+	}
+	key := strings.TrimSpace(content[:colon])
+	val := strings.TrimSpace(content[colon+1:])
+	// Reject obvious non-meta bullets — anything with whitespace in the
+	// key isn't a metadata pair. Keeps us from treating a `### Files`
+	// list (e.g. `- composeApp/src/...`) as metadata.
+	if strings.ContainsAny(key, " \t") {
+		return "", "", false
+	}
+	return key, val, true
+}
+
+// ParseAllMemories returns the parsed entries for every memory file
+// known to the brain, keyed by canonical section name (decisions,
+// bugfixes, testing, integrations, releases). Files that don't exist
+// resolve to empty slices.
+func ParseAllMemories(p BrainPaths) (map[string][]MemoryEntry, error) {
+	out := make(map[string][]MemoryEntry, len(MemoryFiles))
+	for _, mf := range MemoryFiles {
+		section := canonicalSection(mf.Name)
+		entries, err := ParseMemoryFile(filepath.Join(p.MemoriesDir, mf.Name))
+		if err != nil {
+			return nil, err
+		}
+		out[section] = entries
+	}
+	return out, nil
+}
+
+// canonicalSection maps a memory filename to the lowercase section name
+// used by filters and CLI flags (e.g. "decisions.md" → "decisions").
+func canonicalSection(filename string) string {
+	return strings.TrimSuffix(filename, ".md")
+}
+
+// sectionForFile is the reverse of canonicalSection. Returns "" if the
+// section name doesn't correspond to any known memory file.
+func fileForSection(section string) string {
+	want := strings.ToLower(strings.TrimSpace(section)) + ".md"
+	for _, mf := range MemoryFiles {
+		if mf.Name == want {
+			return mf.Name
+		}
+	}
+	return ""
+}
+
+// AllSectionNames returns the canonical section names in display order.
+func AllSectionNames() []string {
+	out := make([]string, 0, len(MemoryFiles))
+	for _, mf := range MemoryFiles {
+		out = append(out, canonicalSection(mf.Name))
+	}
+	return out
+}

--- a/cli/internal/brain/memory_parse_test.go
+++ b/cli/internal/brain/memory_parse_test.go
@@ -1,0 +1,185 @@
+package brain
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseMemoryFile_BasicEntry(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "decisions.md")
+	mustWrite(t, path, `# Decisions
+
+<!-- header comment -->
+
+## Use Koin as DI
+
+- id: use-koin-as-di-20260510-123045
+- type: architecture_decision
+- status: active
+- platform: shared
+- area: dependency_injection
+- date: 2026-05-10
+
+### Decision
+Use Koin.
+
+### Reason
+KMP-friendly.
+
+### Files
+- composeApp/src/commonMain/Module.kt
+`)
+
+	entries, err := ParseMemoryFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.File != "decisions.md" {
+		t.Errorf("File = %q", e.File)
+	}
+	if e.Title != "Use Koin as DI" {
+		t.Errorf("Title = %q", e.Title)
+	}
+	wantMeta := map[string]string{
+		"id":       "use-koin-as-di-20260510-123045",
+		"type":     "architecture_decision",
+		"status":   "active",
+		"platform": "shared",
+		"area":     "dependency_injection",
+		"date":     "2026-05-10",
+	}
+	for k, v := range wantMeta {
+		if got := e.Meta[k]; got != v {
+			t.Errorf("Meta[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if !strings.Contains(e.Body, "### Decision") || !strings.Contains(e.Body, "Use Koin.") {
+		t.Errorf("Body missing expected content:\n%s", e.Body)
+	}
+	// `### Files` list items must NOT be parsed as metadata pairs — the
+	// keys would contain `/` and produce garbage. Verify they end up
+	// in the Body instead.
+	if !strings.Contains(e.Body, "- composeApp/src/commonMain/Module.kt") {
+		t.Errorf("Files list should stay in body:\n%s", e.Body)
+	}
+	if _, leaked := e.Meta["composeApp/src/commonMain/Module.kt"]; leaked {
+		t.Error("file path leaked into Meta as a key")
+	}
+}
+
+func TestParseMemoryFile_MultipleEntries(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "bugfixes.md")
+	mustWrite(t, path, `# Bugfixes
+
+## First
+
+- id: first-1
+- status: active
+
+body of first
+
+## Second
+
+- id: second-2
+- status: temporary
+- review_after: 2026-09-01
+
+body of second
+`)
+	entries, err := ParseMemoryFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	if entries[0].Title != "First" || entries[1].Title != "Second" {
+		t.Errorf("titles = %q, %q", entries[0].Title, entries[1].Title)
+	}
+	if entries[1].Get("review_after") != "2026-09-01" {
+		t.Errorf("review_after for second = %q", entries[1].Get("review_after"))
+	}
+	if !strings.Contains(entries[0].Body, "body of first") {
+		t.Errorf("first.Body = %q", entries[0].Body)
+	}
+}
+
+func TestParseMemoryFile_MissingFileIsEmpty(t *testing.T) {
+	entries, err := ParseMemoryFile(filepath.Join(t.TempDir(), "nope.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestParseMemoryFile_EntryWithoutMetadata(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "decisions.md")
+	mustWrite(t, path, `## Just a title with no meta
+
+Some body content.
+`)
+	entries, err := ParseMemoryFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if len(entries[0].Meta) != 0 {
+		t.Errorf("Meta should be empty for entry without bullets, got %v", entries[0].Meta)
+	}
+	if !strings.Contains(entries[0].Body, "Some body content") {
+		t.Errorf("Body missing: %q", entries[0].Body)
+	}
+}
+
+func TestParseAllMemories_GroupsBySection(t *testing.T) {
+	p := initBrainForTest(t)
+	mustWrite(t, filepath.Join(p.MemoriesDir, "decisions.md"),
+		"## Dec1\n\n- id: d1\n- status: active\n\nbody d1\n")
+	mustWrite(t, filepath.Join(p.MemoriesDir, "bugfixes.md"),
+		"## Bug1\n\n- id: b1\n- status: temporary\n\nbody b1\n")
+
+	groups, err := ParseAllMemories(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups["decisions"]) != 1 || groups["decisions"][0].Title != "Dec1" {
+		t.Errorf("decisions = %+v", groups["decisions"])
+	}
+	if len(groups["bugfixes"]) != 1 || groups["bugfixes"][0].Title != "Bug1" {
+		t.Errorf("bugfixes = %+v", groups["bugfixes"])
+	}
+	// Sections with no entries are still present (empty slice) so the
+	// renderer can show "No entries yet" without a map-lookup miss.
+	if _, ok := groups["testing"]; !ok {
+		t.Error("testing section should exist as empty slice")
+	}
+}
+
+func TestFileForSection(t *testing.T) {
+	cases := map[string]string{
+		"decisions":    "decisions.md",
+		"  Bugfixes ":  "bugfixes.md",
+		"testing":      "testing.md",
+		"integrations": "integrations.md",
+		"releases":     "releases.md",
+		"nope":         "",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := fileForSection(in); got != want {
+			t.Errorf("fileForSection(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/internal/brain/search.go
+++ b/cli/internal/brain/search.go
@@ -1,0 +1,72 @@
+package brain
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SearchHit is a single match emitted by Search.
+type SearchHit struct {
+	Section string      // canonical section name (decisions/bugfixes/...)
+	Entry   MemoryEntry // the matched entry
+	Snippet string      // first body line containing the query (or title if matched there)
+}
+
+// Search returns every entry that matches both query and filter. The
+// query is a case-insensitive substring matched against title and body
+// — filter constraints (platform/status/area) apply on top with AND
+// semantics.
+//
+// Returns hits in canonical section order (decisions → bugfixes →
+// testing → integrations → releases), then in the order entries appear
+// in their source file.
+func Search(p BrainPaths, query string, filter EntryFilter) ([]SearchHit, error) {
+	groups, err := ParseAllMemories(p)
+	if err != nil {
+		return nil, fmt.Errorf("parsear memorias: %w", err)
+	}
+	full := filter
+	if q := strings.TrimSpace(query); q != "" {
+		full.Query = q
+	}
+
+	var hits []SearchHit
+	for _, section := range AllSectionNames() {
+		for _, e := range groups[section] {
+			if !full.Matches(e) {
+				continue
+			}
+			hits = append(hits, SearchHit{
+				Section: section,
+				Entry:   e,
+				Snippet: snippetFor(e, full.Query),
+			})
+		}
+	}
+	return hits, nil
+}
+
+// snippetFor returns the most relevant single line of e for query.
+// Preference: the first body line containing query (case-insensitive);
+// falls back to the title.
+func snippetFor(e MemoryEntry, query string) string {
+	if query == "" {
+		return firstNonEmptyLine(e.Body)
+	}
+	q := strings.ToLower(query)
+	for _, line := range strings.Split(e.Body, "\n") {
+		if strings.Contains(strings.ToLower(line), q) {
+			return strings.TrimSpace(line)
+		}
+	}
+	return e.Title
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}

--- a/cli/internal/brain/search_test.go
+++ b/cli/internal/brain/search_test.go
@@ -1,0 +1,110 @@
+package brain
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSearch_MatchesTitleAndBody(t *testing.T) {
+	p := initBrainForTest(t)
+	mustWrite(t, filepath.Join(p.MemoriesDir, "decisions.md"),
+		"## Use Koin as DI\n\n- id: d1\n- status: active\n\nKoin is KMP-friendly.\n")
+	mustWrite(t, filepath.Join(p.MemoriesDir, "bugfixes.md"),
+		"## FirebaseAuth iOS module renaming\n\n- id: b1\n- status: temporary\n- platform: ios\n\n### Solution\nKeep composeApp lowercase.\n")
+
+	hits, err := Search(p, "koin", EntryFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Entry.Title != "Use Koin as DI" {
+		t.Fatalf("expected 1 hit for koin, got %d: %v", len(hits), hitTitles(hits))
+	}
+
+	hits, _ = Search(p, "firebaseauth", EntryFilter{})
+	if len(hits) != 1 || hits[0].Section != "bugfixes" {
+		t.Errorf("firebaseauth should hit bugfixes, got: %v", hits)
+	}
+}
+
+func TestSearch_FilterANDsWithQuery(t *testing.T) {
+	p := initBrainForTest(t)
+	mustWrite(t, filepath.Join(p.MemoriesDir, "bugfixes.md"),
+		`## Firebase crash on iOS
+
+- id: a1
+- status: temporary
+- platform: ios
+
+solution body
+
+## Firebase crash on Android
+
+- id: a2
+- status: active
+- platform: android
+
+solution body
+`)
+	// Query matches both, but filter narrows to iOS only.
+	hits, err := Search(p, "firebase", EntryFilter{Platform: "ios"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Entry.Get("platform") != "ios" {
+		t.Errorf("expected 1 ios hit, got %d: %v", len(hits), hitTitles(hits))
+	}
+}
+
+func TestSearch_NoMatchReturnsEmpty(t *testing.T) {
+	p := initBrainForTest(t)
+	mustWrite(t, filepath.Join(p.MemoriesDir, "decisions.md"),
+		"## X\n\n- id: x\n\nbody\n")
+	hits, err := Search(p, "nonexistent-query", EntryFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("expected 0 hits, got %d", len(hits))
+	}
+}
+
+func TestSearch_SnippetPrefersBodyLineWithQuery(t *testing.T) {
+	p := initBrainForTest(t)
+	mustWrite(t, filepath.Join(p.MemoriesDir, "decisions.md"),
+		"## Generic title\n\n- id: x\n\nFirst line of body.\nLine mentioning koin specifically.\nThird line.\n")
+	hits, err := Search(p, "koin", EntryFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("got %d hits", len(hits))
+	}
+	if hits[0].Snippet != "Line mentioning koin specifically." {
+		t.Errorf("snippet = %q", hits[0].Snippet)
+	}
+}
+
+func TestSearch_PreservesSectionOrder(t *testing.T) {
+	p := initBrainForTest(t)
+	// Plant a "foo" match in both bugfixes and decisions. Search should
+	// return decisions first (canonical order: decisions → bugfixes …).
+	mustWrite(t, filepath.Join(p.MemoriesDir, "bugfixes.md"),
+		"## foo bug\n\n- id: b\n\nfoo\n")
+	mustWrite(t, filepath.Join(p.MemoriesDir, "decisions.md"),
+		"## foo decision\n\n- id: d\n\nfoo\n")
+	hits, err := Search(p, "foo", EntryFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 2 || hits[0].Section != "decisions" || hits[1].Section != "bugfixes" {
+		t.Errorf("section order broken: got %v", hitTitles(hits))
+	}
+}
+
+func hitTitles(hits []SearchHit) []string {
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = h.Section + "/" + h.Entry.Title
+	}
+	return out
+}

--- a/cli/internal/cmd/brain.go
+++ b/cli/internal/cmd/brain.go
@@ -26,7 +26,13 @@ func NewBrainCmd() *cobra.Command {
 			"decisiones, bugfixes, patrones de testing e integraciones. " +
 			"Vive en <repo>/.mobiai/brain/ — separado del estado global de la CLI.",
 	}
-	root.AddCommand(newBrainInitCmd(), newBrainScanCmd(), newBrainContextCmd(), newBrainSaveCmd())
+	root.AddCommand(
+		newBrainInitCmd(),
+		newBrainScanCmd(),
+		newBrainContextCmd(),
+		newBrainSaveCmd(),
+		newBrainSearchCmd(),
+	)
 	return root
 }
 
@@ -204,9 +210,20 @@ func newBrainContextCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "context",
 		Short: "Imprime el contexto Markdown del Brain (config + scan + memorias)",
-		RunE:  runBrainContext,
+		Long: "Imprime el contexto del Brain como Markdown. Sin flags, vuelca todo. " +
+			"Con --section, --platform, --status o --area filtra entradas de las " +
+			"memorias para que solo aparezca lo relevante (útil cuando el brain crece).",
+		RunE: runBrainContext,
 	}
 	brainCommonFlags(c)
+	c.Flags().StringSlice("section", nil,
+		"limita las secciones a renderizar (stack,rules,decisions,bugfixes,testing,integrations,releases,warnings). Repetible o coma-separado.")
+	c.Flags().String("platform", "",
+		"filtra entradas por platform (android|ios|shared|kmp|flutter|react-native)")
+	c.Flags().String("status", "",
+		"filtra entradas por status (active|temporary|deprecated)")
+	c.Flags().String("area", "",
+		"filtra entradas cuyo area contenga este string (substring)")
 	return c
 }
 
@@ -227,9 +244,102 @@ func runBrainContext(c *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	md := brain.BuildContext(cfg, scan, paths)
+	sections, _ := c.Flags().GetStringSlice("section")
+	platform, _ := c.Flags().GetString("platform")
+	status, _ := c.Flags().GetString("status")
+	area, _ := c.Flags().GetString("area")
+	md := brain.BuildContextWith(cfg, scan, paths, brain.ContextOptions{
+		Sections: sections,
+		Filter: brain.EntryFilter{
+			Platform: platform,
+			Status:   status,
+			Area:     area,
+		},
+	})
 	fmt.Fprint(c.OutOrStdout(), md)
 	return nil
+}
+
+func newBrainSearchCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Busca texto libre en las memorias del Brain",
+		Long: "Hace match case-insensitive sobre el título y el cuerpo de cada " +
+			"entrada de las memorias. Los flags --platform/--status/--area filtran " +
+			"los resultados con semántica AND.",
+		Args: cobra.MinimumNArgs(1),
+		RunE: runBrainSearch,
+	}
+	brainCommonFlags(c)
+	c.Flags().String("platform", "", "limita a entradas con este platform")
+	c.Flags().String("status", "", "limita a entradas con este status")
+	c.Flags().String("area", "", "limita a entradas cuya area contenga este string")
+	return c
+}
+
+func runBrainSearch(c *cobra.Command, args []string) error {
+	out := c.OutOrStdout()
+	info, err := resolveBrainRoot(c)
+	if err != nil {
+		return err
+	}
+	paths := brain.NewBrainPaths(info.Path)
+	if !paths.Exists() {
+		return fmt.Errorf("brain no inicializado en %s — corré `mobiai brain init` primero", info.Path)
+	}
+	query := strings.Join(args, " ")
+	platform, _ := c.Flags().GetString("platform")
+	status, _ := c.Flags().GetString("status")
+	area, _ := c.Flags().GetString("area")
+	hits, err := brain.Search(paths, query, brain.EntryFilter{
+		Platform: platform,
+		Status:   status,
+		Area:     area,
+	})
+	if err != nil {
+		return err
+	}
+	if len(hits) == 0 {
+		fmt.Fprintf(out, "Sin resultados para %q.\n", query)
+		return nil
+	}
+	fmt.Fprintf(out, "%d resultado(s) para %q:\n\n", len(hits), query)
+	for _, h := range hits {
+		// Format: `[section] title (status, platform) — snippet`
+		var meta []string
+		if s := h.Entry.Get("status"); s != "" {
+			meta = append(meta, s)
+		}
+		if p := h.Entry.Get("platform"); p != "" {
+			meta = append(meta, p)
+		}
+		suffix := ""
+		if len(meta) > 0 {
+			suffix = " (" + strings.Join(meta, ", ") + ")"
+		}
+		fmt.Fprintf(out, "[%s] %s%s\n", h.Section, h.Entry.Title, suffix)
+		if h.Snippet != "" {
+			fmt.Fprintf(out, "    %s\n", truncate(h.Snippet, 120))
+		}
+		if id := h.Entry.Get("id"); id != "" {
+			fmt.Fprintf(out, "    id: %s\n", id)
+		}
+		fmt.Fprintln(out)
+	}
+	return nil
+}
+
+// truncate cuts s at maxLen with an ellipsis, avoiding a slice on a
+// multi-byte rune boundary.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
 }
 
 func newBrainSaveCmd() *cobra.Command {

--- a/cli/internal/cmd/brain_filters_test.go
+++ b/cli/internal/cmd/brain_filters_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// brainWithEntries spins up a brain in a KMP project tree, runs scan,
+// and seeds memories with one decision (active/shared) and two bugfixes
+// (one ios/temporary, one android/active). Returns the project root.
+func brainWithEntries(t *testing.T) string {
+	t.Helper()
+	root := setupKMPProject(t)
+	_ = runBrain(t, []string{"init", "--root", root})
+	_ = runBrain(t, []string{"scan", "--root", root})
+	_ = runBrain(t, []string{
+		"save", "decision",
+		"--root", root,
+		"--title", "Use Koin as DI",
+		"--platform", "shared",
+		"--area", "dependency_injection",
+		"--body", "Koin keeps KMP simple.",
+	})
+	_ = runBrain(t, []string{
+		"save", "bugfix",
+		"--root", root,
+		"--title", "FirebaseAuth iOS module renaming",
+		"--platform", "ios",
+		"--status", "temporary",
+		"--area", "firebase_auth",
+		"--body", "Keep composeApp lowercase.",
+	})
+	_ = runBrain(t, []string{
+		"save", "bugfix",
+		"--root", root,
+		"--title", "Crash on empty cart Android",
+		"--platform", "android",
+		"--area", "cart",
+		"--body", "Null-check items before [0].",
+	})
+	return root
+}
+
+func TestBrainContext_FilterByPlatform(t *testing.T) {
+	root := brainWithEntries(t)
+	out := runBrain(t, []string{"context", "--root", root, "--platform", "ios"})
+
+	// iOS bugfix passes the filter.
+	if !strings.Contains(out, "FirebaseAuth iOS") {
+		t.Errorf("expected iOS bugfix in output:\n%s", out)
+	}
+	// android bugfix drops out.
+	if strings.Contains(out, "Crash on empty cart Android") {
+		t.Errorf("android bugfix should be filtered out:\n%s", out)
+	}
+	// shared decision drops out (platform=shared, filter=ios).
+	if strings.Contains(out, "Use Koin as DI") {
+		t.Errorf("shared decision should be filtered out:\n%s", out)
+	}
+	// Memory sections without matches show the filter empty-state, not
+	// the "No entries yet" string used for genuinely empty sections.
+	if !strings.Contains(out, "_No entries match the current filter._") {
+		t.Errorf("expected filter empty-state marker:\n%s", out)
+	}
+}
+
+func TestBrainContext_FilterByStatus(t *testing.T) {
+	root := brainWithEntries(t)
+	out := runBrain(t, []string{"context", "--root", root, "--status", "temporary"})
+
+	if !strings.Contains(out, "FirebaseAuth iOS") {
+		t.Errorf("temporary bugfix should pass:\n%s", out)
+	}
+	if strings.Contains(out, "Crash on empty cart Android") {
+		t.Errorf("active bugfix should be filtered out:\n%s", out)
+	}
+	if strings.Contains(out, "Use Koin as DI") {
+		t.Errorf("active decision should be filtered out:\n%s", out)
+	}
+}
+
+func TestBrainContext_SectionRestriction(t *testing.T) {
+	root := brainWithEntries(t)
+	out := runBrain(t, []string{"context", "--root", root, "--section", "decisions"})
+
+	if !strings.Contains(out, "## Architecture Decisions") {
+		t.Errorf("Architecture Decisions section missing:\n%s", out)
+	}
+	if !strings.Contains(out, "Use Koin as DI") {
+		t.Errorf("decision should be rendered:\n%s", out)
+	}
+	// Bugfixes / Testing / Stack / Rules / Warnings all dropped.
+	for _, banned := range []string{
+		"## Known Bugfixes",
+		"## Testing Patterns",
+		"## Detected Stack",
+		"## Project Rules",
+		"## Warnings",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("section %q should NOT appear with --section decisions:\n%s", banned, out)
+		}
+	}
+}
+
+func TestBrainContext_MultipleSections(t *testing.T) {
+	root := brainWithEntries(t)
+	out := runBrain(t, []string{
+		"context", "--root", root,
+		"--section", "stack,decisions",
+	})
+	if !strings.Contains(out, "## Detected Stack") {
+		t.Errorf("stack should appear:\n%s", out)
+	}
+	if !strings.Contains(out, "## Architecture Decisions") {
+		t.Errorf("decisions should appear:\n%s", out)
+	}
+	if strings.Contains(out, "## Known Bugfixes") {
+		t.Errorf("bugfixes should NOT appear:\n%s", out)
+	}
+}
+
+func TestBrainSearch_FindsByQuery(t *testing.T) {
+	root := brainWithEntries(t)
+	out := runBrain(t, []string{"search", "--root", root, "koin"})
+	if !strings.Contains(out, "Use Koin as DI") {
+		t.Errorf("koin search should find the decision:\n%s", out)
+	}
+	if !strings.Contains(out, "[decisions]") {
+		t.Errorf("output should include section tag:\n%s", out)
+	}
+	if !strings.Contains(out, "id: use-koin") {
+		t.Errorf("output should include id:\n%s", out)
+	}
+}
+
+func TestBrainSearch_FilterANDsWithQuery(t *testing.T) {
+	root := brainWithEntries(t)
+	// Both bugfixes match "ios" via... actually only one does. Use
+	// firebase + platform filter.
+	out := runBrain(t, []string{
+		"search", "--root", root,
+		"--platform", "ios",
+		"firebase",
+	})
+	if !strings.Contains(out, "FirebaseAuth iOS") {
+		t.Errorf("expected firebase iOS hit:\n%s", out)
+	}
+	if strings.Contains(out, "Crash on empty cart Android") {
+		t.Errorf("android bugfix should not appear:\n%s", out)
+	}
+}
+
+func TestBrainSearch_NoResultsMessage(t *testing.T) {
+	root := brainWithEntries(t)
+	out := runBrain(t, []string{"search", "--root", root, "kubernetes"})
+	if !strings.Contains(out, "Sin resultados") {
+		t.Errorf("expected no-results message:\n%s", out)
+	}
+}
+
+func TestBrainSearch_RequiresInit(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := NewBrainCmd()
+	cmd.SetArgs([]string{"search", "--root", tmp, "anything"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("search without init should fail")
+	}
+}
+
+func TestBrainContext_NoFilterPreservesOldOutput(t *testing.T) {
+	root := brainWithEntries(t)
+	out := runBrain(t, []string{"context", "--root", root})
+
+	// Sanity: full output includes all 3 entries + all the standard
+	// headers. This guards against the filter refactor breaking the
+	// default no-flag behavior.
+	for _, want := range []string{
+		"# MobiAI Brain Context",
+		"## Detected Stack",
+		"## Project Rules",
+		"## Architecture Decisions",
+		"Use Koin as DI",
+		"## Known Bugfixes",
+		"FirebaseAuth iOS",
+		"Crash on empty cart Android",
+		"## Warnings",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in default output:\n%s", want, out)
+		}
+	}
+}
+

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -2,7 +2,7 @@
 
 MobiAI Brain es la **memoria viva por proyecto** del ecosistema MobiAI. Mientras las skills enseñan a la IA *cómo* trabajar, el Brain guarda el *conocimiento específico* de cada proyecto mobile: decisiones, bugfixes, workarounds, patrones de testing e integraciones.
 
-> Esta es la Fase 1 (`init` + `scan` + `context`). Los subcomandos `save` y `search` llegan en la Fase 2.
+> Comandos disponibles hoy: `init`, `scan`, `context` (con filtros), `save decision|bugfix|testing`, `search`. Próximos pasos en el [Roadmap](#roadmap).
 
 ## ¿Por qué Brain?
 
@@ -26,11 +26,13 @@ Eso no entra cómodo en CLAUDE.md (no es regla estable) ni en una skill (no es m
 ```bash
 mobiai brain init                  # Crea .mobiai/brain/ en el proyecto actual (idempotente)
 mobiai brain scan                  # Detecta stack: Android, iOS, KMP, Flutter, RN, librerías, CI/CD
-mobiai brain context               # Imprime Markdown con config + scan + memorias
+mobiai brain context               # Imprime Markdown con config + scan + memorias (acepta filtros)
 
 mobiai brain save decision ...     # Guarda una decisión de arquitectura
 mobiai brain save bugfix ...       # Guarda un bugfix o workaround
 mobiai brain save testing ...      # Guarda un patrón de testing reusable
+
+mobiai brain search <query>        # Busca texto libre en las memorias
 ```
 
 Todos aceptan `--root <ruta>` para apuntar a un proyecto distinto del directorio actual.
@@ -119,6 +121,19 @@ El tipo interno (`type:` en la entrada renderizada) se deriva del subcomando + s
 
 Cada entrada recibe un `id` estable basado en el slug del título + timestamp UTC, así dos saves con el mismo título no colisionan.
 
+### `mobiai brain search <query>`
+
+Búsqueda case-insensitive sobre el título y el cuerpo de cada entrada de las memorias. Devuelve por sección, con título, status/platform y un snippet de la primera línea que contiene la query.
+
+```bash
+mobiai brain search koin
+mobiai brain search --platform ios firebase
+mobiai brain search --status temporary
+mobiai brain search --area firebase_auth keystore
+```
+
+Acepta los mismos filtros que `context` (`--platform`, `--status`, `--area`) con semántica **AND**. La query se combina con los filtros: `--platform ios firebase` devuelve solo entradas iOS que mencionen "firebase".
+
 ### `mobiai brain context`
 
 Lee `config.json`, `scan.json` (si existe) y todas las memorias. Imprime un Markdown listo para agentes:
@@ -159,6 +174,28 @@ Platforms: android, ios, shared
 - archivo sensible detectado: .env (no leído)
 ```
 
+**Filtros disponibles**:
+
+| Flag | Notas |
+|---|---|
+| `--section` | Coma-separado o repetible. Nombres canónicos: `stack`, `rules`, `decisions`, `bugfixes`, `testing`, `integrations`, `releases`, `warnings`. |
+| `--platform` | Filtra entradas por `platform:` (exacto, case-insensitive). |
+| `--status` | Filtra por `status:` (exacto). |
+| `--area` | Filtra por `area:` (substring). |
+
+Los filtros aplican solo a entradas de memorias — `stack`, `rules` y `warnings` se incluyen/excluyen únicamente vía `--section`. Si tras filtrar una sección no quedan entradas, aparece `_No entries match the current filter._` (distinto del `_No entries yet._` para secciones genuinamente vacías).
+
+```bash
+# Solo bugfixes temporales para iOS
+mobiai brain context --section bugfixes --platform ios --status temporary
+
+# Solo el stack detectado, sin memorias
+mobiai brain context --section stack
+
+# Decisiones + bugfixes de plataforma shared
+mobiai brain context --section decisions,bugfixes --platform shared
+```
+
 ## Diferencia frente a otros conceptos
 
 | | Skills | CLAUDE.md / AGENTS.md / GEMINI.md | MobiAI Brain |
@@ -175,13 +212,12 @@ Platforms: android, ios, shared
 ## Roadmap
 
 **Fase 1** — `init`, `scan`, `context`. ✓
-**Fase 2 (este PR)** — `save decision|bugfix|testing` + hook en `mobiai-fix-issue`. ✓
+**Fase 2** — `save decision|bugfix|testing` + hook en `mobiai-fix-issue`. ✓
+**Fase 3** — `search` + filtros (`--section`, `--platform`, `--status`, `--area`) en `context`. ✓
 
 **Próximos pasos**:
+- Auto-save desde más skills (`mobiai-write-tests` → testing pattern, `mobiai-mobile-debugging` → bugfix sin pasar por fix-issue).
 - `save integration` y `save release` (categorías de menor volumen).
-- `search <query>` con grep simple sobre los `.md`.
-- Flags `--section` / `--platform` en `context`.
-- Auto-save desde más skills (`mobiai-write-tests` → testing pattern, `mobiai-mobile-debugging` → bugfix).
 - MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente.
 
-**Fase futura** — migración a SQLite + FTS5 si Markdown se queda corto.
+**Fase futura** — migración a SQLite + FTS5 si Markdown se queda corto (>~500 entradas por proyecto). Para el rango actual (1-100 entradas) los filtros sobre Markdown bastan.

--- a/plugins/core/skills/mobiai-brain/SKILL.md
+++ b/plugins/core/skills/mobiai-brain/SKILL.md
@@ -24,14 +24,38 @@ If the project has no `.mobiai/brain/` yet and the user wants project memory, su
 ```
 mobiai brain init                  # Create .mobiai/brain/ in the project (idempotent)
 mobiai brain scan                  # Detect stack: Android / iOS / KMP / Flutter / RN + libs
-mobiai brain context               # Print Markdown context: config + scan + memories
+mobiai brain context               # Print Markdown context: config + scan + memories (filterable)
 
 mobiai brain save decision         # Append an architecture decision
 mobiai brain save bugfix           # Append a bugfix or workaround
 mobiai brain save testing          # Append a reusable testing pattern
+
+mobiai brain search <query>        # Free-text search over memories
 ```
 
-`search` is still coming in a future phase — for now use `mobiai brain context` (or grep over `.mobiai/brain/memories/*.md` directly) to retrieve.
+### Retrieving the right subset
+
+As a project's brain grows, dumping everything via `brain context` wastes tokens. Both `context` and `search` accept the same filters with AND semantics:
+
+| Flag | Notes |
+|---|---|
+| `--section` | Only on `context`. Comma-separated or repeated: `stack`, `rules`, `decisions`, `bugfixes`, `testing`, `integrations`, `releases`, `warnings`. |
+| `--platform` | `android` \| `ios` \| `shared` \| `kmp` \| `flutter` \| `react-native`. Exact match. |
+| `--status` | `active` \| `temporary` \| `deprecated`. Exact match. |
+| `--area` | Substring match against the `area:` metadata. |
+
+Examples for skills/agents:
+
+```bash
+# Before making an iOS Firebase change — pull only iOS Firebase memory.
+mobiai brain context --platform ios --area firebase
+
+# Before writing tests — pull only testing patterns.
+mobiai brain context --section testing
+
+# Quick lookup before proposing a workaround — has it been done before?
+mobiai brain search "module renaming" --platform ios
+```
 
 ### `save` flags
 


### PR DESCRIPTION
## Summary

- **Issue**: el brain crece → \`brain context\` come tokens. Esta PR introduce filtros en \`context\` y un nuevo \`brain search\` para que retrieval sea selectiva.
- **Approach**: parser estructurado de memorias + AND-filter (platform/status/area) + comando search. Sigue siendo todo Markdown — sin SQLite, sin embeddings.

## Why each change

- **Parser estructurado** (\`memory_parse.go\`): hasta ahora \`context\` imprimía los .md verbatim. Sin estructura no hay filtros confiables ni search. El parser produce \`MemoryEntry{Title, Meta, Body}\` que es la base de todo lo demás y deja una migración a SQLite trivial si llegamos a necesitarla.
- **Filter** (\`filter.go\`): genérico, reusable entre \`context\` y \`search\`. AND semantics, case-insensitive, substring para \`area\`. Mantiene la lógica de matching en un solo lugar.
- **Refactor de \`BuildContext\`**: \`BuildContext(cfg, scan, p)\` sigue existiendo y se comporta igual que antes (back-compat — \`mobiai-fix-issue\` hook lo llama así). \`BuildContextWith(cfg, scan, p, opts)\` es la versión nueva que el CLI invoca con flags.
- **\`brain search <query>\`**: free-text sobre title + body, acepta los mismos filtros que \`context\`. Output con \`[section] title (status, platform) + snippet + id\` — usable a ojo y greppeable a línea.
- **Flags en \`brain context\`**: \`--section\` (lista), \`--platform\`, \`--status\`, \`--area\`. Cuando un filtro deja una sección sin entradas se distingue el caso "no había nada" del "filtro descartó todo" (mensajes distintos).
- **Doc + skill update**: \`docs/brain.md\` documenta los nuevos comandos y filtros; \`mobiai-brain\` SKILL.md le dice al agente cómo retrievear el subset relevante en lugar de pedir todo el context.

## Platform

- **Affected platform**: ninguna específica — feature del CLI (\`MobiAI-Core\`).
- **Min Go**: igual que el resto (\`go 1.25.0\`).

## Changes

- \`cli/internal/brain/memory_parse.go\` — \`MemoryEntry\`, \`ParseMemoryFile\`, \`ParseAllMemories\`, helpers de sección.
- \`cli/internal/brain/filter.go\` — \`EntryFilter\` con AND semantics + \`FilterEntries\`.
- \`cli/internal/brain/search.go\` — \`Search(p, query, filter) -> []SearchHit\` con snippet selection.
- \`cli/internal/brain/context.go\` — refactor a \`BuildContextWith(opts)\` usando el parser; mantiene \`BuildContext\` para back-compat.
- \`cli/internal/cmd/brain.go\` — flags \`--section/--platform/--status/--area\` en \`context\`; nuevo subcomando \`search\`.
- Tests nuevos en \`brain/\` (parser, filter, search) y \`cmd/\` (integración full).
- \`docs/brain.md\` + \`plugins/core/skills/mobiai-brain/SKILL.md\` — documentación y guía de uso para skills.

## Test Plan

- [x] \`go build ./...\` limpio
- [x] \`go test ./...\` todo verde — incluye los nuevos paquetes (\`brain/filter\`, \`brain/search\`, \`brain/memory_parse\`) + tests de integración en \`cmd/\`
- [x] Smoke contra TaykusKMP:
  - [x] \`brain search koin\` → 1 hit, sección decisions, snippet correcto
  - [x] \`brain search cart --platform android\` → 1 hit en bugfixes, filtro respetado
  - [x] \`brain context --section decisions\` → solo esa sección, sin stack/rules/warnings
  - [x] \`brain context --platform shared --section decisions,bugfixes\` → decision Koin pasa, bugfix android queda fuera con marker "No entries match filter"
- [x] CLI existente intacta: \`brain init/scan/save/context\` (sin flags) siguen funcionando exactamente igual que antes
- [x] El test \`TestBrainContext_NoFilterPreservesOldOutput\` guarda contra regresiones de la modalidad sin flags

## Regression Risk

- [ ] Toca lifecycle de Activity/Fragment o ViewController — N/A
- [ ] Toca threading / coroutines / Dispatchers / GCD — N/A
- [ ] Toca navegación o deep links — N/A
- [ ] Modifica ProGuard/R8 o build settings de iOS — N/A
- [ ] Cambia versiones de dependencias — N/A (no se agregan deps a \`go.mod\`)
- **Risk notes**: refactor de \`BuildContext\` — la API pública sigue con la misma firma. El render pasa por parser → emisor estructurado, así que entradas escritas a mano con formato no canónico pueden cambiar de output (los \`save\` siempre producen formato canónico, así que ese path está cubierto por tests). Si una memoria editada a mano tiene una sección \`### Files\` con paths con \`:\`, el parser ya filtra ese caso (test \`TestParseMemoryFile_BasicEntry\` lo cubre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)