### PR TITLE
feat(brain): hooks de save en write-tests, mobile-debugging y brainstorming

### DIFF
--- a/docs/brain.md
+++ b/docs/brain.md
@@ -207,17 +207,28 @@ mobiai brain context --section decisions,bugfixes --platform shared
 
 ## Integración con skills
 
-`mobiai-fix-issue` propone guardar el bugfix automáticamente al final de Phase 6 (verification), pero **solo si** el proyecto ya tiene un brain inicializado. Si no, el hook se salta sin ruido. Otras skills (write-tests, mobile-debugging, etc.) seguirán el mismo patrón a medida que se vayan integrando.
+Tres skills proponen guardar al final de su flujo, todas con el mismo patrón: **solo si** existe `.mobiai/brain/config.json` en el proyecto, y **siempre** pidiendo aprobación al usuario antes de invocar el save.
+
+| Skill | Cuándo propone | Tipo guardado |
+|---|---|---|
+| `mobiai-fix-issue` | Tras Phase 6 (verification), antes del PR gate | `bugfix` (status según haya fix real o workaround) |
+| `mobiai-write-tests` | Tras Step 4 (tests pasan), si el test captura un patrón no obvio | `testing` |
+| `mobiai-mobile-debugging` | Tras Phase 6 (root cause confirmada), **solo en invocación standalone** — si se invocó desde fix-issue, se salta (fix-issue ya tiene su propio hook) | `bugfix` |
+
+Si el proyecto **no** tiene brain, el hook se salta sin ruido. El agente nunca invoca `save` solo: siempre pide una línea de confirmación al usuario antes de ejecutarlo.
+
+Otras skills que podrían integrarse en el futuro: `mobiai-mobile-brainstorming` (decisiones de diseño → `save decision`), `mobiai-crashlytics` (crashes recurrentes → `save bugfix`).
 
 ## Roadmap
 
 **Fase 1** — `init`, `scan`, `context`. ✓
 **Fase 2** — `save decision|bugfix|testing` + hook en `mobiai-fix-issue`. ✓
 **Fase 3** — `search` + filtros (`--section`, `--platform`, `--status`, `--area`) en `context`. ✓
+**Fase 4** — hooks de save en `mobiai-write-tests` (testing pattern) y `mobiai-mobile-debugging` (bugfix sin pasar por fix-issue). ✓
 
 **Próximos pasos**:
-- Auto-save desde más skills (`mobiai-write-tests` → testing pattern, `mobiai-mobile-debugging` → bugfix sin pasar por fix-issue).
+- Hook en `mobiai-mobile-brainstorming` → `save decision` cuando una sesión de brainstorming termina en una decisión.
 - `save integration` y `save release` (categorías de menor volumen).
-- MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente.
+- MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente sin invocar la CLI.
 
 **Fase futura** — migración a SQLite + FTS5 si Markdown se queda corto (>~500 entradas por proyecto). Para el rango actual (1-100 entradas) los filtros sobre Markdown bastan.

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -214,21 +214,22 @@ Tres skills proponen guardar al final de su flujo, todas con el mismo patrón: *
 | `mobiai-fix-issue` | Tras Phase 6 (verification), antes del PR gate | `bugfix` (status según haya fix real o workaround) |
 | `mobiai-write-tests` | Tras Step 4 (tests pasan), si el test captura un patrón no obvio | `testing` |
 | `mobiai-mobile-debugging` | Tras Phase 6 (root cause confirmada), **solo en invocación standalone** — si se invocó desde fix-issue, se salta (fix-issue ya tiene su propio hook) | `bugfix` |
+| `mobiai-mobile-brainstorming` | Tras User Review Gate (spec aprobada), una entrada por cada decisión arquitectónica no trivial del spec | `decision` |
 
 Si el proyecto **no** tiene brain, el hook se salta sin ruido. El agente nunca invoca `save` solo: siempre pide una línea de confirmación al usuario antes de ejecutarlo.
 
-Otras skills que podrían integrarse en el futuro: `mobiai-mobile-brainstorming` (decisiones de diseño → `save decision`), `mobiai-crashlytics` (crashes recurrentes → `save bugfix`).
+Otras skills que podrían integrarse en el futuro: `mobiai-crashlytics` (crashes recurrentes → `save bugfix`), `mobiai-mobile-planning` (planes con decisiones embebidas → `save decision`).
 
 ## Roadmap
 
 **Fase 1** — `init`, `scan`, `context`. ✓
 **Fase 2** — `save decision|bugfix|testing` + hook en `mobiai-fix-issue`. ✓
 **Fase 3** — `search` + filtros (`--section`, `--platform`, `--status`, `--area`) en `context`. ✓
-**Fase 4** — hooks de save en `mobiai-write-tests` (testing pattern) y `mobiai-mobile-debugging` (bugfix sin pasar por fix-issue). ✓
+**Fase 4** — hooks de save en `mobiai-write-tests` (testing pattern), `mobiai-mobile-debugging` (bugfix sin pasar por fix-issue) y `mobiai-mobile-brainstorming` (decision tras spec aprobada). ✓
 
 **Próximos pasos**:
-- Hook en `mobiai-mobile-brainstorming` → `save decision` cuando una sesión de brainstorming termina en una decisión.
-- `save integration` y `save release` (categorías de menor volumen).
-- MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente sin invocar la CLI.
+- **MCP tools** (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) — el agente invoca el Brain directamente como tool en vez de delegar al usuario que recuerde correr la CLI. Cambia adopción de "el agente puede usar el brain si la skill se lo indica" a "el brain está siempre en su toolbox".
+- `save integration` y `save release` (categorías de menor volumen, baja prioridad).
+- `mobiai brain review` — listar entradas `status: temporary` cuyo `review_after` ya pasó (para que workarounds temporales no se vuelvan permanentes por inercia).
 
 **Fase futura** — migración a SQLite + FTS5 si Markdown se queda corto (>~500 entradas por proyecto). Para el rango actual (1-100 entradas) los filtros sobre Markdown bastan.

--- a/plugins/core/skills/mobiai-mobile-brainstorming/SKILL.md
+++ b/plugins/core/skills/mobiai-mobile-brainstorming/SKILL.md
@@ -107,6 +107,40 @@ After the spec review passes, ask the user to review the written spec before pro
 
 Wait for the user's response. Only proceed once the user approves.
 
+**Optional: capture decisions in MobiAI Brain**
+
+After the user approves the spec, check whether `<repo>/.mobiai/brain/config.json` exists. If it does NOT, skip this step silently.
+
+If it does, scan the spec for **architectural decisions worth remembering**. A decision belongs in the brain when it:
+
+- Picks a specific library, pattern or approach over alternatives (e.g. "Koin over Hilt", "MVI over MVVM", "Ktor over Retrofit").
+- Sets a project-wide convention that future code will follow (e.g. "all features expose a `Repository` interface", "errors flow as `Result<T, E>`").
+- Resolves a tradeoff that took real thought (e.g. "we accept duplicate state across screens to avoid a global store").
+
+Skip routine implementation details that are obvious from the spec itself ("the button is blue", "the screen has a back arrow"). Those don't need to live in the brain — the spec already captures them.
+
+If you find 1+ decisions worth saving, **propose** each save to the user (one-line confirmation per entry). Never invoke silently. A single brainstorming session may produce several distinct decisions — save them as separate entries so future `brain search` and filtering work cleanly:
+
+```bash
+mobiai brain save decision \
+  --title "<short decision name, e.g. 'Use Koin for DI'>" \
+  --platform <android|ios|shared|kmp|flutter|react-native> \
+  --area <free-form, e.g. dependency_injection | navigation | state_management> \
+  --status active \
+  --files "<spec_path>,<any_other_relevant_file>" \
+  --body "### Decision
+What we decided, in one sentence.
+
+### Reason
+Why this over the alternatives. What constraints made the alternatives worse.
+
+### Alternatives considered
+- <option A> — why rejected
+- <option B> — why rejected"
+```
+
+The body's `### Alternatives considered` block is the high-leverage part — it's why future agents won't re-litigate the same decision. Include it when the decision had real tradeoffs.
+
 **Implementation:**
 
 - Invoke the `mobiai-mobile-planning` skill to create a detailed implementation plan

--- a/plugins/core/skills/mobiai-mobile-debugging/SKILL.md
+++ b/plugins/core/skills/mobiai-mobile-debugging/SKILL.md
@@ -217,8 +217,45 @@ Once the hypothesis is verified, state:
 
 The fix itself is not proposed inside this skill. `mobiai-mobile-debugging` ends when the root cause is stated (fast path) or confirmed (gated path).
 
-- If invoked from `mobiai-fix-issue`, return control — `mobiai-fix-issue`'s Phase 4 (Propose the Fix) takes over with its own gating rules.
+- If invoked from `mobiai-fix-issue`, return control — `mobiai-fix-issue`'s Phase 4 (Propose the Fix) takes over with its own gating rules. **Skip the Brain hook below** — `mobiai-fix-issue` runs its own save proposal at the end of Phase 6 (verification). Don't double-prompt.
 - Otherwise, **invoke skill `mobiai-mobile-tdd`** to write the failing test first, then the implementation.
+
+### Optional: capture root cause in MobiAI Brain
+
+Standalone invocations only (skip when called from `mobiai-fix-issue`). After the root cause is confirmed, check whether `<repo>/.mobiai/brain/config.json` exists. If it does NOT, skip silently.
+
+If it does, judge whether the cause is worth remembering. Save when:
+
+- It's a platform gotcha that's likely to bite again (lifecycle timing, threading, build-config interaction).
+- The investigation surfaced a non-obvious causal chain that took real effort to find.
+- A workaround was identified that the project will keep using until a future cleanup.
+
+Skip when the cause is trivial (typo, obvious null, one-line bug with no broader pattern).
+
+When worth saving, **propose** the save to the user (one-line confirmation). Never invoke silently. Use `--status active` when the root cause is documented but no fix is applied yet (the entry serves as "we understood this, future agents should know"), or `--status temporary` with `--review-after` when a workaround was applied that needs revisiting.
+
+```bash
+mobiai brain save bugfix \
+  --title "<short, e.g. 'Compose recomposition loop in LazyColumn with derivedStateOf'>" \
+  --platform <android|ios|shared|kmp|flutter|react-native> \
+  --area <free-form, e.g. compose | coroutines | gradle> \
+  --status <active|temporary> \
+  --review-after <YYYY-MM-DD if temporary> \
+  --files "<file1>,<file2>" \
+  --body "### Symptom
+What the user observed.
+
+### Root Cause
+The actual cause, in plain language.
+
+### Investigation Notes
+The evidence that confirmed it — log lines, commits, behavior on different builds.
+
+### Resolution
+What was done about it (or 'documented only, no fix applied yet')."
+```
+
+The body fields are suggestions, not a rigid template. Use the structure that fits what you found.
 
 ## Red Flags — STOP and Follow Process
 

--- a/plugins/core/skills/mobiai-write-tests/SKILL.md
+++ b/plugins/core/skills/mobiai-write-tests/SKILL.md
@@ -56,6 +56,34 @@ Run the test suite to verify:
 
 If tests fail, fix them. If existing tests fail and your fix caused the regression, fix that too.
 
+### Step 5: Capture in MobiAI Brain (if worth remembering)
+
+Once tests pass, check whether `<repo>/.mobiai/brain/config.json` exists. If it does NOT, skip this step silently — not every project uses Brain.
+
+If it does, decide whether this test is a **reusable pattern** worth saving as a `testing_pattern` entry. A test is worth saving when it captures a non-obvious mobile-specific gotcha — async/lifecycle timing, platform quirks, flaky-test workarounds, fixture patterns. Skip when the test is a routine assertion on business logic.
+
+When it's worth saving, **propose** the save to the user first (one-line confirmation). Never invoke silently. Suggested invocation:
+
+```bash
+mobiai brain save testing \
+  --title "<short pattern name, e.g. 'DataStore clear waits for empty emission'>" \
+  --platform <android|ios|shared|kmp|flutter|react-native> \
+  --area <free-form, e.g. datastore | coroutines | xctest | maestro> \
+  --files "<test_file>,<sut_file>" \
+  --body "### Problem
+What goes wrong without this pattern (race, leak, false pass, etc.).
+
+### Solution
+The pattern itself, in one paragraph.
+
+### Example
+\`\`\`kotlin
+// minimal code snippet
+\`\`\`"
+```
+
+Skip the body's `### Example` block on languages that don't fit. The fewer placeholders, the better — concrete pattern in the user's own words beats a generic template.
+
 ## Platform Conventions
 
 ### Android (Kotlin)


### PR DESCRIPTION
## Summary

- **Issue**: Hasta esta PR solo \`mobiai-fix-issue\` capturaba al brain. El volumen quedaba acotado a "bugs fixeados vía pipeline completo" — todo lo aprendido escribiendo tests, investigando standalone, o decidiendo arquitectura en sesiones de brainstorming se perdía.
- **Approach**: Replicar el patrón del hook de fix-issue en las tres skills donde naturalmente aparece conocimiento valioso sin pasar por fix-issue: \`mobiai-write-tests\`, \`mobiai-mobile-debugging\` y \`mobiai-mobile-brainstorming\`.

## Why each change

- **\`mobiai-write-tests\`** — nuevo Step 5: tras tests verdes, si el test captura un patrón no obvio (timing async, lifecycle, flaky workarounds, fixtures), propone \`brain save testing\`. Skipea tests rutinarios de business logic.
- **\`mobiai-mobile-debugging\`** — extensión de Phase 6, **solo en invocación standalone**: si se invocó desde fix-issue, se salta (fix-issue ya tiene su propio hook → evitamos double-prompt). Propone \`brain save bugfix\` cuando la cause es worth remembering (platform gotcha, causal chain no obvia, workaround conocido).
- **\`mobiai-mobile-brainstorming\`** — nueva sección tras el User Review Gate y antes de delegar a planning. Cierra el gap del archivo huérfano (\`decisions.md\`): ninguna otra skill capturaba decisiones arquitectónicas. Propone \`brain save decision\` por cada decisión no trivial del spec — pueden ser varias por sesión (DI + navegación + state management → 3 entries separadas). Body sugerido incluye \`### Alternatives considered\` que es el bloque más valioso (evita relitigio).
- **\`docs/brain.md\`** — tabla "Integración con skills" extendida con las 4 skills que tienen hook + roadmap actualizado: próximo gran paso es MCP tools.

Patrón común a las 4 skills (incluyendo fix-issue ya existente):
- **Guard**: si \`.mobiai/brain/config.json\` no existe → skip silencioso.
- **Approval**: una línea de confirmación del usuario antes de cada \`save\`.
- **Nunca corre solo**, **nunca crea el brain solo**.
- **Criterios explícitos** de "vale la pena guardar" — skipea trivialidades, captura patrones reusables y decisiones no obvias.

## Platform

- **Affected platform**: ninguna específica. Cambios de SKILL.md (Markdown), zero código.
- **Min Go**: N/A (sin cambios en \`cli/\`).

## Changes

- \`plugins/core/skills/mobiai-write-tests/SKILL.md\` — Step 5 con criterios + comando de ejemplo.
- \`plugins/core/skills/mobiai-mobile-debugging/SKILL.md\` — extensión de Phase 6 con criterios + nota de skipear cuando se invoca desde fix-issue.
- \`plugins/core/skills/mobiai-mobile-brainstorming/SKILL.md\` — sección nueva tras el User Review Gate con multi-entry guidance.
- \`docs/brain.md\` — tabla "Integración con skills" + roadmap a Fase 5 (MCP).

## Test Plan

- [x] No hay tests automatizados — SKILL.md son instrucciones para agentes.
- [x] CLI no afectada: \`go build\` y \`go test\` siguen verdes.
- [ ] Smoke recomendado: invocar cada skill en un proyecto con brain inicializado y verificar que el flujo dispara el prompt al final. Invocar \`mobiai-fix-issue\` para verificar que el hook de debugging NO dispara (porque ya lo cubre fix-issue).
- [x] Cambios estructurados: cada hook tiene guard + approval + ejemplo de comando + criterios de cuándo skipear.

## Regression Risk

- [ ] Cambio de comportamiento aditivo: cada hook va al **final** del workflow, después del trabajo principal. Si el usuario dice no al prompt, el flow es idéntico al previo.
- [ ] Guards explícitos: proyectos sin brain ven cero cambios.
- [ ] El hook de debugging tiene check explícito ("if invoked from fix-issue, skip") para evitar prompts duplicados.
- **Risk notes**: si un usuario tiene invocaciones scripteadas que no esperan el prompt, podría confundirse. Mitigación: el prompt pide una línea, no bloquea — el flow continúa si el usuario dice no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)