### PR TITLE
feat(brain): hook de save decision en mobiai-mobile-brainstorming

### DIFF
--- a/docs/brain.md
+++ b/docs/brain.md
@@ -214,21 +214,22 @@ Tres skills proponen guardar al final de su flujo, todas con el mismo patrón: *
 | `mobiai-fix-issue` | Tras Phase 6 (verification), antes del PR gate | `bugfix` (status según haya fix real o workaround) |
 | `mobiai-write-tests` | Tras Step 4 (tests pasan), si el test captura un patrón no obvio | `testing` |
 | `mobiai-mobile-debugging` | Tras Phase 6 (root cause confirmada), **solo en invocación standalone** — si se invocó desde fix-issue, se salta (fix-issue ya tiene su propio hook) | `bugfix` |
+| `mobiai-mobile-brainstorming` | Tras User Review Gate (spec aprobada), una entrada por cada decisión arquitectónica no trivial del spec | `decision` |
 
 Si el proyecto **no** tiene brain, el hook se salta sin ruido. El agente nunca invoca `save` solo: siempre pide una línea de confirmación al usuario antes de ejecutarlo.
 
-Otras skills que podrían integrarse en el futuro: `mobiai-mobile-brainstorming` (decisiones de diseño → `save decision`), `mobiai-crashlytics` (crashes recurrentes → `save bugfix`).
+Otras skills que podrían integrarse en el futuro: `mobiai-crashlytics` (crashes recurrentes → `save bugfix`), `mobiai-mobile-planning` (planes con decisiones embebidas → `save decision`).
 
 ## Roadmap
 
 **Fase 1** — `init`, `scan`, `context`. ✓
 **Fase 2** — `save decision|bugfix|testing` + hook en `mobiai-fix-issue`. ✓
 **Fase 3** — `search` + filtros (`--section`, `--platform`, `--status`, `--area`) en `context`. ✓
-**Fase 4** — hooks de save en `mobiai-write-tests` (testing pattern) y `mobiai-mobile-debugging` (bugfix sin pasar por fix-issue). ✓
+**Fase 4** — hooks de save en `mobiai-write-tests` (testing pattern), `mobiai-mobile-debugging` (bugfix sin pasar por fix-issue) y `mobiai-mobile-brainstorming` (decision tras spec aprobada). ✓
 
 **Próximos pasos**:
-- Hook en `mobiai-mobile-brainstorming` → `save decision` cuando una sesión de brainstorming termina en una decisión.
-- `save integration` y `save release` (categorías de menor volumen).
-- MCP tools (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) para que el agente llame al Brain directamente sin invocar la CLI.
+- **MCP tools** (`mobile_context`, `mobile_save_decision`, `mobile_search`, ...) — el agente invoca el Brain directamente como tool en vez de delegar al usuario que recuerde correr la CLI. Cambia adopción de "el agente puede usar el brain si la skill se lo indica" a "el brain está siempre en su toolbox".
+- `save integration` y `save release` (categorías de menor volumen, baja prioridad).
+- `mobiai brain review` — listar entradas `status: temporary` cuyo `review_after` ya pasó (para que workarounds temporales no se vuelvan permanentes por inercia).
 
 **Fase futura** — migración a SQLite + FTS5 si Markdown se queda corto (>~500 entradas por proyecto). Para el rango actual (1-100 entradas) los filtros sobre Markdown bastan.

--- a/plugins/core/skills/mobiai-mobile-brainstorming/SKILL.md
+++ b/plugins/core/skills/mobiai-mobile-brainstorming/SKILL.md
@@ -107,6 +107,40 @@ After the spec review passes, ask the user to review the written spec before pro
 
 Wait for the user's response. Only proceed once the user approves.
 
+**Optional: capture decisions in MobiAI Brain**
+
+After the user approves the spec, check whether `<repo>/.mobiai/brain/config.json` exists. If it does NOT, skip this step silently.
+
+If it does, scan the spec for **architectural decisions worth remembering**. A decision belongs in the brain when it:
+
+- Picks a specific library, pattern or approach over alternatives (e.g. "Koin over Hilt", "MVI over MVVM", "Ktor over Retrofit").
+- Sets a project-wide convention that future code will follow (e.g. "all features expose a `Repository` interface", "errors flow as `Result<T, E>`").
+- Resolves a tradeoff that took real thought (e.g. "we accept duplicate state across screens to avoid a global store").
+
+Skip routine implementation details that are obvious from the spec itself ("the button is blue", "the screen has a back arrow"). Those don't need to live in the brain — the spec already captures them.
+
+If you find 1+ decisions worth saving, **propose** each save to the user (one-line confirmation per entry). Never invoke silently. A single brainstorming session may produce several distinct decisions — save them as separate entries so future `brain search` and filtering work cleanly:
+
+```bash
+mobiai brain save decision \
+  --title "<short decision name, e.g. 'Use Koin for DI'>" \
+  --platform <android|ios|shared|kmp|flutter|react-native> \
+  --area <free-form, e.g. dependency_injection | navigation | state_management> \
+  --status active \
+  --files "<spec_path>,<any_other_relevant_file>" \
+  --body "### Decision
+What we decided, in one sentence.
+
+### Reason
+Why this over the alternatives. What constraints made the alternatives worse.
+
+### Alternatives considered
+- <option A> — why rejected
+- <option B> — why rejected"
+```
+
+The body's `### Alternatives considered` block is the high-leverage part — it's why future agents won't re-litigate the same decision. Include it when the decision had real tradeoffs.
+
 **Implementation:**
 
 - Invoke the `mobiai-mobile-planning` skill to create a detailed implementation plan


### PR DESCRIPTION
## Summary

- **Issue**: \`decisions.md\` quedaba huérfano — fix-issue / write-tests / mobile-debugging cubren bugfixes y testing patterns, pero las decisiones arquitectónicas no las captura nadie.
- **Approach**: Mismo patrón de hook que las otras 3 skills, ubicado justo después del User Review Gate de brainstorming, antes de delegar a planning.

**Nota**: stackeado sobre PR #9 (\`feat/brain-save-hooks\`). Cuando #9 mergee, retargeteo este a \`brain-integration\`.

## Why each change

- **\`mobiai-mobile-brainstorming\` SKILL.md** — añade sección "Optional: capture decisions in MobiAI Brain" después del User Review Gate y antes del paso de "Implementation". El punto del flujo es deliberado: el spec ya fue aprobado, las decisiones están confirmadas, y antes de delegar a planning el agente tiene contexto fresco de qué se decidió y por qué.
- **Criterios explícitos** de qué guardar: librería/pattern/enfoque elegido sobre alternativas, conventions project-wide, tradeoffs no triviales. Skipea detalles obvios de implementación que ya viven en el spec.
- **Multi-entry**: una sesión de brainstorming puede producir varias decisiones (DI + navegación + state management). El hook explícitamente sugiere guardarlas como entradas separadas para que \`brain search\` y filtros funcionen limpios.
- **Body sugerido** incluye \`### Alternatives considered\` porque ése es el bloque más valioso del entry — evita que futuros agentes relitiguen la misma decisión.
- **\`docs/brain.md\`** — tabla de integración extendida con la 4ta skill, roadmap actualizado: próximo gran paso es MCP tools.

## Platform

- **Affected platform**: ninguna específica. Cambios de SKILL.md (Markdown), zero código.
- **Min Go**: N/A.

## Changes

- \`plugins/core/skills/mobiai-mobile-brainstorming/SKILL.md\` — nueva sub-sección "Optional: capture decisions in MobiAI Brain".
- \`docs/brain.md\` — tabla "Integración con skills" + roadmap.

## Test Plan

- [x] No hay tests automatizados — SKILL.md son instrucciones para agentes.
- [x] CLI no afectada (zero cambios en \`cli/\`); \`go build\` y \`go test\` siguen verdes.
- [ ] Smoke recomendado: invocar \`mobiai-mobile-brainstorming\` en un proyecto con brain inicializado, llegar al User Review Gate aprobado, y verificar que el agente propone save de las decisiones del spec.

## Regression Risk

- [ ] Cambio de comportamiento en skill existente — aditivo: el hook va en una sub-sección nueva entre el User Review Gate y la delegación a planning. Si el usuario dice no al prompt, el flujo continúa idéntico al previo.
- [ ] El hook tiene guard de \`.mobiai/brain/config.json\` — proyectos sin brain ven cero cambios en el flujo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)