### PR TITLE
feat(graph): MobiAI Graph V1 — indexador Kotlin/Swift + CLI + skill

### DIFF
--- a/cli/cmd/mobiai/main.go
+++ b/cli/cmd/mobiai/main.go
@@ -107,6 +107,7 @@ func newRootCmd(v string) *cobra.Command {
 	root.AddCommand(cmd.NewUpdateCmd())
 	root.AddCommand(cmd.NewTelemetryCmd())
 	root.AddCommand(cmd.NewBrainCmd())
+	root.AddCommand(cmd.NewGraphCmd())
 	return root
 }
 

--- a/cli/internal/branding/banner.go
+++ b/cli/internal/branding/banner.go
@@ -1,0 +1,88 @@
+// Package branding centralizes MobiAI's visual identity in the CLI —
+// banners, taglines, color choices. Kept in a separate package so any
+// command can pull it in without cyclic imports.
+package branding
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// banner is the MOBIAI wordmark in block-style ASCII. Hand-crafted to
+// match the visual we agreed on with the team; do not regenerate from
+// figlet — the spacing was tweaked by hand.
+const banner = `███╗   ███╗  ██████╗  ██████╗  ██╗       ██████╗  ██╗
+████╗ ████║ ██╔═══██╗ ██╔══██╗ ██║      ██╔═══██╗ ██║
+██╔████╔██║ ██║   ██║ ██████╔╝ ██║      ███████║ ██║
+██║╚██╔╝██║ ██║   ██║ ██╔══██╗ ██║      ██╔══██║ ██║
+██║ ╚═╝ ██║ ╚██████╔╝ ██████╔╝ ██║      ██║  ██║ ██║
+╚═╝     ╚═╝  ╚═════╝  ╚═════╝  ╚═╝      ╚═╝  ╚═╝ ╚═╝`
+
+// tagline appears centered-ish under the wordmark. Short and stable —
+// don't seasonally rewrite, it's part of the brand identity.
+const tagline = "            AI FOR MOBILE DEVELOPERS"
+
+// ANSI color codes used for the colorized variant. Bright cyan for
+// the wordmark (reads well on both light and dark terminals), dim
+// white for the tagline so it doesn't shout louder than the logo.
+const (
+	colorBannerStart  = "\033[1;36m" // bold cyan
+	colorTaglineStart = "\033[2;37m" // dim white
+	colorReset        = "\033[0m"
+)
+
+// Render returns the full banner string (wordmark + blank line +
+// tagline + trailing newline). When useColor is true, wraps the parts
+// in ANSI escape codes; otherwise returns plain UTF-8.
+//
+// Callers should pass false when:
+//   - The --no-color flag is set.
+//   - The NO_COLOR env var is non-empty (https://no-color.org/).
+//   - Output is being piped/redirected (not a TTY).
+//
+// shouldUseColor() below covers the env / TTY checks; the --no-color
+// flag check is the caller's job since this package has no view of
+// cobra flags.
+func Render(useColor bool) string {
+	if useColor {
+		return colorBannerStart + banner + colorReset + "\n\n" +
+			colorTaglineStart + tagline + colorReset + "\n"
+	}
+	return banner + "\n\n" + tagline + "\n"
+}
+
+// Print writes the rendered banner to w, deciding color automatically
+// based on noColorFlag (typically GlobalFlags.NoColor) combined with
+// env-var and TTY checks. Convenience wrapper for the common case.
+func Print(w io.Writer, noColorFlag bool) {
+	useColor := !noColorFlag && shouldUseColor(w)
+	fmt.Fprint(w, Render(useColor))
+}
+
+// shouldUseColor reports whether ANSI escapes are appropriate for w.
+// Returns false when:
+//   - NO_COLOR env var is set (any non-empty value, per the spec).
+//   - w is a file but not a terminal (piped/redirected output).
+//
+// Conservative on the side of "no color" so CI logs and `cmd > file`
+// stay clean.
+func shouldUseColor(w io.Writer) bool {
+	if v := strings.TrimSpace(os.Getenv("NO_COLOR")); v != "" {
+		return false
+	}
+	// If the writer is *os.File, check whether it's a terminal. Other
+	// writer types (bytes.Buffer in tests, log writers, etc.) we leave
+	// to the caller's noColorFlag decision.
+	if f, ok := w.(*os.File); ok {
+		fi, err := f.Stat()
+		if err != nil {
+			return false
+		}
+		// Character device = terminal. Pipes and files don't have this
+		// mode bit set.
+		return (fi.Mode() & os.ModeCharDevice) != 0
+	}
+	return true
+}

--- a/cli/internal/branding/banner_test.go
+++ b/cli/internal/branding/banner_test.go
@@ -1,0 +1,65 @@
+package branding
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRender_PlainHasNoEscapes(t *testing.T) {
+	out := Render(false)
+	if strings.Contains(out, "\033[") {
+		t.Errorf("plain render should not contain ANSI escapes:\n%s", out)
+	}
+	// Sanity: the wordmark and tagline are both present.
+	if !strings.Contains(out, "MOBILE DEVELOPERS") {
+		t.Errorf("tagline missing in plain render:\n%s", out)
+	}
+}
+
+func TestRender_ColorWrapsInEscapes(t *testing.T) {
+	out := Render(true)
+	if !strings.Contains(out, "\033[1;36m") {
+		t.Errorf("colored render should include the cyan start escape:\n%s", out)
+	}
+	if !strings.Contains(out, "\033[0m") {
+		t.Errorf("colored render should include the reset escape:\n%s", out)
+	}
+}
+
+func TestPrint_NoColorFlagSuppressesEscapes(t *testing.T) {
+	var buf bytes.Buffer
+	Print(&buf, true) // noColorFlag = true → never color
+	if strings.Contains(buf.String(), "\033[") {
+		t.Errorf("Print with noColorFlag=true should not emit escapes:\n%s", buf.String())
+	}
+}
+
+func TestPrint_NonTTYDoesNotColor(t *testing.T) {
+	// bytes.Buffer is not a TTY — shouldUseColor returns true for
+	// non-*os.File writers as a safe default, but the caller's
+	// noColorFlag should still gate it. With noColorFlag=false here,
+	// we expect color (the caller's choice).
+	var buf bytes.Buffer
+	Print(&buf, false)
+	if !strings.Contains(buf.String(), "\033[") {
+		t.Errorf("Print with bytes.Buffer + noColorFlag=false should color (caller opted in):\n%s", buf.String())
+	}
+}
+
+func TestShouldUseColor_RespectsNoColorEnv(t *testing.T) {
+	// NO_COLOR set → never color, regardless of writer.
+	t.Setenv("NO_COLOR", "1")
+	if shouldUseColor(&bytes.Buffer{}) {
+		t.Errorf("NO_COLOR=1 should disable color")
+	}
+}
+
+func TestShouldUseColor_EmptyNoColorEnvIsNoOp(t *testing.T) {
+	// NO_COLOR="" should NOT disable color (per the spec: any
+	// non-empty value disables).
+	t.Setenv("NO_COLOR", "")
+	if !shouldUseColor(&bytes.Buffer{}) {
+		t.Errorf("empty NO_COLOR should not disable color")
+	}
+}

--- a/cli/internal/cmd/brain.go
+++ b/cli/internal/cmd/brain.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/brain"
 	brainmcp "github.com/ArisGuimera/MobiAI-Core/cli/internal/brain/mcp"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/branding"
 )
 
 // NewBrainCmd builds `mobiai brain <init|scan|context>`.
@@ -83,6 +84,14 @@ func newBrainInitCmd() *cobra.Command {
 
 func runBrainInit(c *cobra.Command, _ []string) error {
 	out := c.OutOrStdout()
+	// Banner first — `brain init` is the user's entry point into the
+	// Brain ecosystem, so it's the right moment to show the wordmark.
+	// Print() handles --no-color, NO_COLOR env, and TTY detection
+	// internally; we just pass the flag value.
+	flags := FlagsFromCmd(c)
+	branding.Print(out, flags.NoColor)
+	fmt.Fprintln(out, "")
+
 	info, err := resolveBrainRoot(c)
 	if err != nil {
 		return err

--- a/cli/internal/cmd/graph.go
+++ b/cli/internal/cmd/graph.go
@@ -1,0 +1,308 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/graph"
+)
+
+// NewGraphCmd builds `mobiai graph <init|status|search|callers|context>`.
+//
+// Phase 1 of MobiAI Graph — a per-project semantic code index for mobile
+// codebases. State lives at <root>/.mobiai/graph/, never in the global
+// ~/.mobiai/ directory (that's the CLI's own state).
+func NewGraphCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "graph",
+		Short: "Exploración semántica del código mobile",
+		Long: "MobiAI Graph indexa el proyecto y permite buscar símbolos, encontrar referencias " +
+			"y obtener contexto relevante para una tarea. Vive en <repo>/.mobiai/graph/.",
+	}
+	root.AddCommand(
+		newGraphInitCmd(),
+		newGraphStatusCmd(),
+		newGraphSearchCmd(),
+		newGraphCallersCmd(),
+		newGraphContextCmd(),
+	)
+	return root
+}
+
+// graphCommonFlags wires up the shared --root flag on a leaf command.
+// When omitted, the command resolves the project root from cwd.
+func graphCommonFlags(c *cobra.Command) {
+	c.Flags().String("root", "", "ruta del proyecto (default: cwd)")
+}
+
+// resolveGraphRoot returns the absolute project root for a graph command.
+// Honors --root if given; otherwise falls back to the current working
+// directory. Unlike Brain, Graph does NOT walk up looking for project
+// markers — it operates on whatever directory the user points it at.
+func resolveGraphRoot(c *cobra.Command) (string, error) {
+	if explicit, _ := c.Flags().GetString("root"); explicit != "" {
+		abs, err := filepath.Abs(explicit)
+		if err != nil {
+			return "", fmt.Errorf("absolutizar --root: %w", err)
+		}
+		info, err := os.Stat(abs)
+		if err != nil || !info.IsDir() {
+			return "", fmt.Errorf("--root no es un directorio: %s", abs)
+		}
+		return abs, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getwd: %w", err)
+	}
+	return filepath.Abs(cwd)
+}
+
+// graphIndexPath returns the canonical on-disk location of the Graph
+// index for the project at root.
+func graphIndexPath(root string) string {
+	return filepath.Join(root, ".mobiai", "graph", "index.json")
+}
+
+// loadGraphIndex reads the index for root, returning a friendly Spanish
+// error suggesting `mobiai graph init` when the file is missing.
+func loadGraphIndex(root string) (*graph.Index, string, error) {
+	path := graphIndexPath(root)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, path, fmt.Errorf("no encontré %s. Corré `mobiai graph init` primero", path)
+	}
+	idx, err := graph.Read(path)
+	if err != nil {
+		return nil, path, fmt.Errorf("leer índice %s: %w", path, err)
+	}
+	return idx, path, nil
+}
+
+func newGraphInitCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "init",
+		Short: "Indexa el proyecto y guarda .mobiai/graph/index.json",
+		RunE:  runGraphInit,
+	}
+	graphCommonFlags(c)
+	return c
+}
+
+func runGraphInit(c *cobra.Command, _ []string) error {
+	out := c.OutOrStdout()
+	root, err := resolveGraphRoot(c)
+	if err != nil {
+		return err
+	}
+
+	idx, err := graph.Build(root)
+	if err != nil {
+		return fmt.Errorf("indexar proyecto: %w", err)
+	}
+
+	path := graphIndexPath(root)
+	if err := graph.Write(path, idx); err != nil {
+		return fmt.Errorf("escribir índice: %w", err)
+	}
+
+	kotlin, swift := countByLanguage(idx)
+	symbols := countSymbols(idx)
+
+	fmt.Fprintf(out, "✓ Índice generado: %s\n", path)
+	fmt.Fprintf(out, "  Archivos: %d\n", len(idx.Files))
+	fmt.Fprintf(out, "  Símbolos: %d\n", symbols)
+	fmt.Fprintf(out, "  Kotlin: %d\n", kotlin)
+	fmt.Fprintf(out, "  Swift: %d\n", swift)
+	return nil
+}
+
+func newGraphStatusCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "status",
+		Short: "Muestra info del índice actual",
+		RunE:  runGraphStatus,
+	}
+	graphCommonFlags(c)
+	return c
+}
+
+func runGraphStatus(c *cobra.Command, _ []string) error {
+	out := c.OutOrStdout()
+	root, err := resolveGraphRoot(c)
+	if err != nil {
+		return err
+	}
+	idx, path, err := loadGraphIndex(root)
+	if err != nil {
+		return err
+	}
+
+	kotlin, swift := countByLanguage(idx)
+	symbols := countSymbols(idx)
+
+	fmt.Fprintf(out, "Índice: %s\n", path)
+	fmt.Fprintf(out, "Generado: %s (%s)\n",
+		idx.GeneratedAt.Format(time.RFC3339), humanizeAge(idx.GeneratedAt))
+	fmt.Fprintf(out, "Archivos: %d\n", len(idx.Files))
+	fmt.Fprintf(out, "Símbolos: %d\n", symbols)
+	fmt.Fprintf(out, "Kotlin: %d\n", kotlin)
+	fmt.Fprintf(out, "Swift: %d\n", swift)
+	return nil
+}
+
+func newGraphSearchCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "search <término>",
+		Short: "Busca símbolos por nombre",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runGraphSearch,
+	}
+	graphCommonFlags(c)
+	return c
+}
+
+func runGraphSearch(c *cobra.Command, args []string) error {
+	out := c.OutOrStdout()
+	root, err := resolveGraphRoot(c)
+	if err != nil {
+		return err
+	}
+	idx, _, err := loadGraphIndex(root)
+	if err != nil {
+		return err
+	}
+	hits := graph.Search(idx, args[0])
+	if len(hits) == 0 {
+		fmt.Fprintln(out, "Sin coincidencias.")
+		return nil
+	}
+	for _, h := range hits {
+		fmt.Fprintf(out, "%s:%d %s %s\n", h.File, h.Symbol.Line, h.Symbol.Kind, h.Symbol.Name)
+	}
+	return nil
+}
+
+func newGraphCallersCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "callers <símbolo>",
+		Short: "Lista referencias textuales del símbolo",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runGraphCallers,
+	}
+	graphCommonFlags(c)
+	return c
+}
+
+func runGraphCallers(c *cobra.Command, args []string) error {
+	out := c.OutOrStdout()
+	root, err := resolveGraphRoot(c)
+	if err != nil {
+		return err
+	}
+	idx, _, err := loadGraphIndex(root)
+	if err != nil {
+		return err
+	}
+	hits := graph.Callers(idx, root, args[0])
+	if len(hits) == 0 {
+		fmt.Fprintln(out, "Sin referencias.")
+		return nil
+	}
+	for _, h := range hits {
+		fmt.Fprintf(out, "%s:%d %s\n", h.File, h.Line, h.Snippet)
+	}
+	return nil
+}
+
+func newGraphContextCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "context <tarea...>",
+		Short: "Archivos relevantes para una tarea (heurística)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  runGraphContext,
+	}
+	graphCommonFlags(c)
+	return c
+}
+
+func runGraphContext(c *cobra.Command, args []string) error {
+	out := c.OutOrStdout()
+	root, err := resolveGraphRoot(c)
+	if err != nil {
+		return err
+	}
+	idx, _, err := loadGraphIndex(root)
+	if err != nil {
+		return err
+	}
+	task := joinArgs(args)
+	hits := graph.Context(idx, task, 10)
+	if len(hits) == 0 {
+		fmt.Fprintln(out, "Sin archivos relevantes encontrados.")
+		return nil
+	}
+	for _, h := range hits {
+		fmt.Fprintf(out, "%s  (score %d)\n", h.File, h.Score)
+	}
+	return nil
+}
+
+// joinArgs joins free-form task tokens with single spaces. Done as a
+// helper (instead of strings.Join inline) so it's easy to swap in
+// smarter normalization later without touching the command body.
+func joinArgs(args []string) string {
+	out := ""
+	for i, a := range args {
+		if i > 0 {
+			out += " "
+		}
+		out += a
+	}
+	return out
+}
+
+// countByLanguage returns (kotlin, swift) file counts in idx.
+func countByLanguage(idx *graph.Index) (int, int) {
+	var k, s int
+	for _, f := range idx.Files {
+		switch f.Language {
+		case "kotlin":
+			k++
+		case "swift":
+			s++
+		}
+	}
+	return k, s
+}
+
+// countSymbols sums the total number of symbols across all files.
+func countSymbols(idx *graph.Index) int {
+	n := 0
+	for _, f := range idx.Files {
+		n += len(f.Symbols)
+	}
+	return n
+}
+
+// humanizeAge renders a Spanish "hace Xm/Xh/Xd" relative timestamp for
+// a past time t. Falls back to "hace Xm" with X=0 for very fresh times.
+func humanizeAge(t time.Time) string {
+	d := time.Since(t)
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Hour {
+		mins := int(d.Round(time.Minute) / time.Minute)
+		return fmt.Sprintf("hace %dm", mins)
+	}
+	if d < 24*time.Hour {
+		hours := int(d.Round(time.Hour) / time.Hour)
+		return fmt.Sprintf("hace %dh", hours)
+	}
+	days := int(d.Round(24*time.Hour) / (24 * time.Hour))
+	return fmt.Sprintf("hace %dd", days)
+}

--- a/cli/internal/cmd/graph_test.go
+++ b/cli/internal/cmd/graph_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runGraph executes a graph subcommand and returns combined stdout/stderr.
+// Fails the test on any execution error.
+func runGraph(t *testing.T, args []string) string {
+	t.Helper()
+	cmd := NewGraphCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("graph %v: %v\noutput:\n%s", args, err, buf.String())
+	}
+	return buf.String()
+}
+
+// writeFile writes content to <root>/<rel>, creating intermediate dirs.
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGraphInit_CreatesIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, filepath.Join("app", "Foo.kt"), "class Foo {}\n")
+
+	cmd := NewGraphCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"init", "--root", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "Índice generado") {
+		t.Errorf("expected 'Índice generado' in output, got: %s", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".mobiai", "graph", "index.json")); err != nil {
+		t.Errorf("index.json not created: %v", err)
+	}
+}
+
+func TestGraphStatus_NoIndex(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd := NewGraphCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status", "--root", dir})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error when index missing, got nil. output:\n%s", out.String())
+	}
+	combined := out.String() + err.Error()
+	if !strings.Contains(combined, "mobiai graph init") {
+		t.Errorf("expected suggestion to run 'mobiai graph init', got: %s", combined)
+	}
+}
+
+func TestGraphStatus_WithIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, filepath.Join("app", "Foo.kt"), "class Foo {}\n")
+
+	_ = runGraph(t, []string{"init", "--root", dir})
+	out := runGraph(t, []string{"status", "--root", dir})
+
+	if !strings.Contains(out, "Archivos:") {
+		t.Errorf("expected 'Archivos:' in status output, got: %s", out)
+	}
+	if !strings.Contains(out, "1") {
+		t.Errorf("expected file count '1' in status output, got: %s", out)
+	}
+}
+
+func TestGraphSearch_FindsSymbol(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, filepath.Join("app", "Foo.kt"), "class Foo {}\n")
+
+	_ = runGraph(t, []string{"init", "--root", dir})
+	out := runGraph(t, []string{"search", "Foo", "--root", dir})
+
+	if !strings.Contains(out, "Foo.kt") {
+		t.Errorf("expected 'Foo.kt' in search output, got: %s", out)
+	}
+	if !strings.Contains(out, "Foo") {
+		t.Errorf("expected symbol 'Foo' in search output, got: %s", out)
+	}
+}
+
+func TestGraphSearch_NoHits(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, filepath.Join("app", "Foo.kt"), "class Foo {}\n")
+
+	_ = runGraph(t, []string{"init", "--root", dir})
+	out := runGraph(t, []string{"search", "Nonexistent", "--root", dir})
+
+	if !strings.Contains(out, "Sin coincidencias.") {
+		t.Errorf("expected 'Sin coincidencias.' message, got: %s", out)
+	}
+}
+
+func TestGraphCallers_FindsRefs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, filepath.Join("app", "a.kt"), "class Foo {}\n")
+	writeFile(t, dir, filepath.Join("app", "b.kt"), "fun bar() { Foo() }\n")
+
+	_ = runGraph(t, []string{"init", "--root", dir})
+	out := runGraph(t, []string{"callers", "Foo", "--root", dir})
+
+	if !strings.Contains(out, "b.kt") {
+		t.Errorf("expected reference in 'b.kt', got: %s", out)
+	}
+}
+
+func TestGraphContext_FindsFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, filepath.Join("app", "login.kt"), "class LoginViewModel {}\n")
+	writeFile(t, dir, filepath.Join("app", "unrelated.kt"), "class WeatherWidget {}\n")
+
+	_ = runGraph(t, []string{"init", "--root", dir})
+	out := runGraph(t, []string{"context", "fix", "login", "bug", "--root", dir})
+
+	if !strings.Contains(out, "login.kt") {
+		t.Errorf("expected 'login.kt' in context output, got: %s", out)
+	}
+	if strings.Contains(out, "unrelated.kt") {
+		t.Errorf("did not expect 'unrelated.kt' in context output, got: %s", out)
+	}
+}

--- a/cli/internal/graph/indexer.go
+++ b/cli/internal/graph/indexer.go
@@ -1,0 +1,127 @@
+package graph
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// defaultExcludedDirs is the set of directory base names skipped during Build.
+// Walks do not descend into these directories. Defined as a var (not const)
+// so a future task can override or extend it.
+var defaultExcludedDirs = map[string]struct{}{
+	".git":         {},
+	".gradle":      {},
+	".idea":        {},
+	".vscode":      {},
+	".mobiai":      {},
+	"build":        {},
+	"dist":         {},
+	"out":          {},
+	"target":       {},
+	"Pods":         {},
+	"DerivedData":  {},
+	"node_modules": {},
+}
+
+// Build walks root recursively, scans every .kt and .swift file with the
+// appropriate scanner, and returns a populated Index. The Root field is set
+// to the absolute path of root. Paths in FileIndex.Path are repo-relative
+// (relative to root, using forward slashes).
+//
+// Directories whose base name is in the default exclusion list are skipped
+// entirely (their subtrees are not walked):
+//
+//	.git .gradle .idea .vscode .mobiai
+//	build dist out target
+//	Pods DerivedData
+//	node_modules
+//
+// Symlinks to directories are not followed.
+func Build(root string) (*Index, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("el directorio %s no existe", root)
+		}
+		return nil, fmt.Errorf("stat %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s no es un directorio", root)
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolver ruta absoluta de %s: %w", root, err)
+	}
+
+	idx := &Index{
+		Version:     IndexVersion,
+		GeneratedAt: time.Now().UTC(),
+		Root:        absRoot,
+		Files:       []FileIndex{},
+	}
+
+	walkErr := filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			// Never skip the root itself, even if its base name happens to
+			// match an excluded entry.
+			if path == absRoot {
+				return nil
+			}
+			if _, skip := defaultExcludedDirs[d.Name()]; skip {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		// Only regular files are considered. filepath.WalkDir does not follow
+		// directory symlinks by default (DirEntry.Type reports the link type).
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext != ".kt" && ext != ".swift" {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(absRoot, path)
+		if err != nil {
+			return fmt.Errorf("ruta relativa de %s: %w", path, err)
+		}
+		relPath = filepath.ToSlash(relPath)
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("leer %s: %w", relPath, err)
+		}
+
+		var fi FileIndex
+		switch ext {
+		case ".kt":
+			fi = ScanKotlin(relPath, content)
+		case ".swift":
+			fi = ScanSwift(relPath, content)
+		}
+		fi.Path = relPath
+		idx.Files = append(idx.Files, fi)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	sort.Slice(idx.Files, func(i, j int) bool {
+		return idx.Files[i].Path < idx.Files[j].Path
+	})
+
+	return idx, nil
+}

--- a/cli/internal/graph/indexer_test.go
+++ b/cli/internal/graph/indexer_test.go
@@ -1,0 +1,217 @@
+package graph
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeFile creates parent directories and writes content to path.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestBuild_FindsKotlinAndSwift(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "app", "src", "main", "kotlin", "Foo.kt"), "class Foo {}\n")
+	writeFile(t, filepath.Join(dir, "ios", "Sources", "Bar.swift"), "struct Bar {}\n")
+
+	idx, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := len(idx.Files); got != 2 {
+		t.Fatalf("want 2 files, got %d", got)
+	}
+
+	// Sorted by Path.
+	paths := []string{idx.Files[0].Path, idx.Files[1].Path}
+	if !sort.StringsAreSorted(paths) {
+		t.Errorf("files not sorted: %v", paths)
+	}
+
+	// Each FileIndex has the correct Language.
+	byPath := map[string]string{}
+	for _, f := range idx.Files {
+		byPath[f.Path] = f.Language
+	}
+	if byPath["app/src/main/kotlin/Foo.kt"] != "kotlin" {
+		t.Errorf("kotlin file language: %q", byPath["app/src/main/kotlin/Foo.kt"])
+	}
+	if byPath["ios/Sources/Bar.swift"] != "swift" {
+		t.Errorf("swift file language: %q", byPath["ios/Sources/Bar.swift"])
+	}
+}
+
+func TestBuild_SkipsExcludedDirs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "app", "src", "main", "kotlin", "Real.kt"), "class Real {}\n")
+	writeFile(t, filepath.Join(dir, "build", "generated", "Fake.kt"), "class Fake {}\n")
+	writeFile(t, filepath.Join(dir, "node_modules", "lib", "Ignore.kt"), "class Ignore {}\n")
+	writeFile(t, filepath.Join(dir, "Pods", "SomePod", "Ignore.swift"), "struct Ignore {}\n")
+	writeFile(t, filepath.Join(dir, ".git", "hooks", "Ignore.kt"), "class Ignore {}\n")
+	writeFile(t, filepath.Join(dir, ".mobiai", "cached", "Ignore.kt"), "class Ignore {}\n")
+
+	idx, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(idx.Files) != 1 {
+		t.Fatalf("want 1 file, got %d: %+v", len(idx.Files), idx.Files)
+	}
+	if idx.Files[0].Path != "app/src/main/kotlin/Real.kt" {
+		t.Errorf("unexpected file: %q", idx.Files[0].Path)
+	}
+}
+
+func TestBuild_PathsAreRepoRelativeForwardSlashes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a", "b", "c", "Foo.kt"), "class Foo {}\n")
+
+	idx, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(idx.Files) != 1 {
+		t.Fatalf("want 1 file, got %d", len(idx.Files))
+	}
+	if idx.Files[0].Path != "a/b/c/Foo.kt" {
+		t.Errorf("path = %q, want %q", idx.Files[0].Path, "a/b/c/Foo.kt")
+	}
+}
+
+func TestBuild_RootIsAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "Foo.kt"), "class Foo {}\n")
+
+	// Use a relative path by chdir'ing into the parent.
+	parent := filepath.Dir(dir)
+	base := filepath.Base(dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(parent); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	idx, err := Build(base)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !filepath.IsAbs(idx.Root) {
+		t.Errorf("Root is not absolute: %q", idx.Root)
+	}
+}
+
+func TestBuild_VersionAndTimestamp(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if idx.Version != IndexVersion {
+		t.Errorf("version = %d, want %d", idx.Version, IndexVersion)
+	}
+	if idx.GeneratedAt.IsZero() {
+		t.Errorf("GeneratedAt is zero")
+	}
+	if idx.GeneratedAt.Location() != time.UTC {
+		t.Errorf("GeneratedAt location = %v, want UTC", idx.GeneratedAt.Location())
+	}
+}
+
+func TestBuild_NonExistentDir(t *testing.T) {
+	idx, err := Build("/this/path/does/not/exist")
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if idx != nil {
+		t.Errorf("want nil index, got %+v", idx)
+	}
+	if !strings.Contains(err.Error(), "no existe") && !strings.Contains(err.Error(), "/this/path/does/not/exist") {
+		t.Errorf("error message %q lacks expected hints", err.Error())
+	}
+}
+
+func TestBuild_NotADirectory(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "regular.txt")
+	if err := os.WriteFile(filePath, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	idx, err := Build(filePath)
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if idx != nil {
+		t.Errorf("want nil index, got %+v", idx)
+	}
+	if !strings.Contains(err.Error(), "no es un directorio") {
+		t.Errorf("error message %q does not mention 'no es un directorio'", err.Error())
+	}
+}
+
+func TestBuild_IgnoresOtherFileExtensions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "app", "Foo.java"), "class Foo {}\n")
+	writeFile(t, filepath.Join(dir, "app", "Bar.cpp"), "int main() {}\n")
+	writeFile(t, filepath.Join(dir, "app", "Doc.md"), "# Doc\n")
+	writeFile(t, filepath.Join(dir, "app", "Foo.kt"), "class Foo {}\n")
+
+	idx, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(idx.Files) != 1 {
+		t.Fatalf("want 1 file, got %d: %+v", len(idx.Files), idx.Files)
+	}
+	if idx.Files[0].Path != "app/Foo.kt" {
+		t.Errorf("unexpected file: %q", idx.Files[0].Path)
+	}
+}
+
+func TestBuild_EmptyProject(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(idx.Files) != 0 {
+		t.Errorf("want 0 files, got %d", len(idx.Files))
+	}
+}
+
+func TestBuild_SortedByPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "z", "Z.kt"), "class Z {}\n")
+	writeFile(t, filepath.Join(dir, "a", "A.kt"), "class A {}\n")
+	writeFile(t, filepath.Join(dir, "m", "M.swift"), "struct M {}\n")
+
+	idx, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(idx.Files) != 3 {
+		t.Fatalf("want 3 files, got %d", len(idx.Files))
+	}
+	want := []string{"a/A.kt", "m/M.swift", "z/Z.kt"}
+	for i, w := range want {
+		if idx.Files[i].Path != w {
+			t.Errorf("Files[%d].Path = %q, want %q", i, idx.Files[i].Path, w)
+		}
+	}
+}

--- a/cli/internal/graph/kotlin.go
+++ b/cli/internal/graph/kotlin.go
@@ -1,0 +1,292 @@
+package graph
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+)
+
+// Compiled regexes used by ScanKotlin. Defined at package level so they are
+// compiled once.
+var (
+	// reImport matches `import com.foo.Bar` or `import com.foo.*`.
+	reImport = regexp.MustCompile(`^\s*import\s+([\w.]+(?:\.\*)?)\s*$`)
+
+	// reType matches class/object/interface declarations with optional
+	// modifiers (group 1 = modifiers, group 2 = keyword, group 3 = name).
+	reType = regexp.MustCompile(`^\s*((?:(?:public|private|internal|protected|open|abstract|sealed|data|inline|inner|enum)\s+)*)(class|object|interface)\s+(\w+)`)
+
+	// reFun matches `fun foo(...)`. Skips generic params and extension
+	// receiver. Group 1 = modifiers, group 2 = function name.
+	reFun = regexp.MustCompile(`^\s*((?:(?:public|private|internal|protected|open|abstract|inline|suspend|override|operator|tailrec)\s+)*)fun\s+(?:<[^>]+>\s+)?(?:[\w.]+\.)?(\w+)\s*\(`)
+)
+
+// containerEntry tracks an open class/object/interface in the brace stack.
+type containerEntry struct {
+	Name  string
+	Depth int // brace depth at which the container body opened
+}
+
+// ScanKotlin parses a Kotlin source file's bytes and returns a FileIndex
+// populated with imports, symbols, language="kotlin", and line count.
+// The path field is set to the path argument verbatim (caller is responsible
+// for passing a repo-relative path).
+func ScanKotlin(path string, content []byte) FileIndex {
+	idx := FileIndex{
+		Path:     path,
+		Language: "kotlin",
+		Lines:    countLines(content),
+		Imports:  []string{},
+		Symbols:  []Symbol{},
+	}
+
+	stripped := stripCommentsAndStrings(content)
+	lines := bytes.Split(stripped, []byte("\n"))
+
+	var stack []containerEntry
+	depth := 0
+
+	for i, rawLine := range lines {
+		lineNum := i + 1
+		line := string(rawLine)
+
+		// Imports: matched against the stripped line (still preserves
+		// identifiers and dots since strings/comments don't contain
+		// well-formed import statements after stripping).
+		if m := reImport.FindStringSubmatch(line); m != nil {
+			idx.Imports = append(idx.Imports, m[1])
+		}
+
+		// Container at the START of this line is the innermost open
+		// type, if any.
+		container := ""
+		if len(stack) > 0 {
+			container = stack[len(stack)-1].Name
+		}
+
+		// Type declarations (class/object/interface).
+		if m := reType.FindStringSubmatch(line); m != nil {
+			modifiers := splitModifiers(m[1])
+			kind := m[2]
+			name := m[3]
+
+			sym := Symbol{
+				Name:      name,
+				Kind:      kind,
+				Line:      lineNum,
+				Container: container,
+				Modifiers: modifiers,
+			}
+			idx.Symbols = append(idx.Symbols, sym)
+
+			// If this line opens a body (`{`), push onto the stack.
+			// Otherwise (single-line declaration without body, or
+			// `class Foo` with body on next line), still push: when
+			// the `{` arrives on a later line we'll already be at
+			// the correct depth. We use the depth AFTER processing
+			// this line's braces below.
+			//
+			// Simplest approach: push with depth = current depth.
+			// When `}` closes, we pop when we drop back BELOW that
+			// depth. We update braces below, then check for pops.
+			//
+			// We push BEFORE processing this line's braces so that
+			// "depth at which body opens" matches the line's `{`.
+			stack = append(stack, containerEntry{Name: name, Depth: depth})
+		} else {
+			// Functions (only checked if line is not a type decl).
+			if m := reFun.FindStringSubmatch(line); m != nil {
+				modifiers := splitModifiers(m[1])
+				name := m[2]
+				sym := Symbol{
+					Name:      name,
+					Kind:      "fun",
+					Line:      lineNum,
+					Container: container,
+					Modifiers: modifiers,
+				}
+				idx.Symbols = append(idx.Symbols, sym)
+			}
+		}
+
+		// Update brace depth based on this line's braces, then pop
+		// any containers whose body has closed.
+		opens := strings.Count(line, "{")
+		closes := strings.Count(line, "}")
+		depth += opens
+		depth -= closes
+
+		// Pop containers whose `body-open depth` is now >= current
+		// depth. A container pushed at depth D opens its body on the
+		// `{` that follows: that brace takes us to D+1. When we
+		// return to depth <= D, the body is closed.
+		for len(stack) > 0 && depth <= stack[len(stack)-1].Depth {
+			stack = stack[:len(stack)-1]
+		}
+	}
+
+	return idx
+}
+
+// splitModifiers splits the modifier prefix captured by the type/fun regexes
+// into a slice of individual modifiers. Returns nil if there are none, so the
+// resulting FileIndex omits the field in JSON.
+func splitModifiers(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Fields(s)
+	if len(parts) == 0 {
+		return nil
+	}
+	return parts
+}
+
+// countLines returns the line count of the original content. Trailing newline
+// or not, an empty file is 0 lines and a non-empty file is at least 1.
+func countLines(content []byte) int {
+	if len(content) == 0 {
+		return 0
+	}
+	n := bytes.Count(content, []byte("\n"))
+	if !bytes.HasSuffix(content, []byte("\n")) {
+		n++
+	}
+	return n
+}
+
+// stripCommentsAndStrings walks the bytes once and replaces the contents of
+// line comments, block comments, and string literals with spaces. Newlines
+// inside the stripped regions are preserved so that line numbers and column
+// positions in the output match the original. This makes downstream regex
+// matching immune to "class X" appearing inside a comment or string.
+//
+// State machine handles:
+//   - line comments: `// ... \n`
+//   - block comments: `/* ... */` (NOT nested — Kotlin's spec says block
+//     comments do nest, but in practice almost no real code relies on it,
+//     and the V1 tests use commented-out inner `/* ... */` text on the same
+//     line which is fine).
+//   - double-quoted strings: `"..."` with `\"` escape.
+//   - triple-quoted raw strings: `"""..."""` (no escapes inside).
+func stripCommentsAndStrings(content []byte) []byte {
+	out := make([]byte, len(content))
+	copy(out, content)
+
+	const (
+		stateCode = iota
+		stateLineComment
+		stateBlockComment
+		stateString       // "..."
+		stateTripleString // """..."""
+	)
+
+	state := stateCode
+	i := 0
+	n := len(content)
+
+	for i < n {
+		c := content[i]
+
+		switch state {
+		case stateCode:
+			// Triple-quoted string opener.
+			if c == '"' && i+2 < n && content[i+1] == '"' && content[i+2] == '"' {
+				// Leave the opening `"""` in place — they aren't
+				// identifiers and won't match our regexes. Just
+				// transition state and advance.
+				i += 3
+				state = stateTripleString
+				continue
+			}
+			if c == '"' {
+				i++
+				state = stateString
+				continue
+			}
+			if c == '/' && i+1 < n && content[i+1] == '/' {
+				// Replace `//` and the rest with spaces until newline.
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				state = stateLineComment
+				continue
+			}
+			if c == '/' && i+1 < n && content[i+1] == '*' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				state = stateBlockComment
+				continue
+			}
+			i++
+
+		case stateLineComment:
+			if c == '\n' {
+				state = stateCode
+				i++
+				continue
+			}
+			out[i] = ' '
+			i++
+
+		case stateBlockComment:
+			if c == '*' && i+1 < n && content[i+1] == '/' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				state = stateCode
+				continue
+			}
+			if c != '\n' {
+				out[i] = ' '
+			}
+			i++
+
+		case stateString:
+			if c == '\\' && i+1 < n {
+				// Escape: blank out the escape and the next byte
+				// (but preserve newline if it's `\` + literal newline).
+				if content[i+1] != '\n' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					continue
+				}
+				out[i] = ' '
+				i++
+				continue
+			}
+			if c == '"' {
+				// Closing quote — leave it.
+				i++
+				state = stateCode
+				continue
+			}
+			if c == '\n' {
+				// Unterminated string — bail back to code mode
+				// to avoid eating the whole file on a stray quote.
+				state = stateCode
+				i++
+				continue
+			}
+			out[i] = ' '
+			i++
+
+		case stateTripleString:
+			if c == '"' && i+2 < n && content[i+1] == '"' && content[i+2] == '"' {
+				// Closing triple quote — leave it in place.
+				i += 3
+				state = stateCode
+				continue
+			}
+			if c != '\n' {
+				out[i] = ' '
+			}
+			i++
+		}
+	}
+
+	return out
+}

--- a/cli/internal/graph/kotlin_test.go
+++ b/cli/internal/graph/kotlin_test.go
@@ -1,0 +1,240 @@
+package graph
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadFixture reads a Kotlin fixture file from testdata/kotlin/.
+func loadFixture(t *testing.T, name string) (string, []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", "kotlin", name)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", path, err)
+	}
+	return path, content
+}
+
+// findSymbol returns the first symbol matching the given name, or nil if not found.
+func findSymbol(symbols []Symbol, name string) *Symbol {
+	for i := range symbols {
+		if symbols[i].Name == name {
+			return &symbols[i]
+		}
+	}
+	return nil
+}
+
+// symbolNames returns just the symbol names for assertions.
+func symbolNames(symbols []Symbol) []string {
+	out := make([]string, len(symbols))
+	for i, s := range symbols {
+		out[i] = s.Name
+	}
+	return out
+}
+
+// contains reports whether s is present in xs.
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScanKotlin_Basic(t *testing.T) {
+	path, content := loadFixture(t, "basic.kt")
+	idx := ScanKotlin(path, content)
+
+	if idx.Language != "kotlin" {
+		t.Errorf("expected language=kotlin, got %q", idx.Language)
+	}
+
+	wantImports := []string{"com.x.y.Foo", "kotlinx.coroutines.flow.Flow"}
+	if len(idx.Imports) != len(wantImports) {
+		t.Fatalf("expected %d imports, got %d: %v", len(wantImports), len(idx.Imports), idx.Imports)
+	}
+	for i, want := range wantImports {
+		if idx.Imports[i] != want {
+			t.Errorf("imports[%d]: want %q, got %q", i, want, idx.Imports[i])
+		}
+	}
+
+	mustHave := []string{
+		"LoginViewModel", "Config", "AuthRepository", "User", "Result",
+		"Success", "Error", "login", "logout", "authenticate", "clear",
+	}
+	for _, name := range mustHave {
+		if findSymbol(idx.Symbols, name) == nil {
+			t.Errorf("expected symbol %q in symbols; got: %v", name, symbolNames(idx.Symbols))
+		}
+	}
+
+	if findSymbol(idx.Symbols, "baseUrl") != nil {
+		t.Errorf("did not expect val/var %q to be extracted in V1", "baseUrl")
+	}
+
+	if login := findSymbol(idx.Symbols, "login"); login != nil {
+		if login.Container != "LoginViewModel" {
+			t.Errorf("login.Container: want LoginViewModel, got %q", login.Container)
+		}
+	}
+
+	if success := findSymbol(idx.Symbols, "Success"); success != nil {
+		if success.Container != "Result" {
+			t.Errorf("Success.Container: want Result, got %q", success.Container)
+		}
+	}
+
+	if user := findSymbol(idx.Symbols, "User"); user != nil {
+		found := false
+		for _, m := range user.Modifiers {
+			if m == "data" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("User.Modifiers should contain \"data\", got %v", user.Modifiers)
+		}
+	}
+
+	if vm := findSymbol(idx.Symbols, "LoginViewModel"); vm != nil {
+		if vm.Container != "" {
+			t.Errorf("LoginViewModel.Container should be empty (top-level), got %q", vm.Container)
+		}
+	}
+}
+
+func TestScanKotlin_IgnoresComments(t *testing.T) {
+	path, content := loadFixture(t, "edge_cases.kt")
+	idx := ScanKotlin(path, content)
+
+	forbidden := []string{"NotARealClass", "AlsoNotReal", "alsoIgnoredFn"}
+	for _, name := range forbidden {
+		if findSymbol(idx.Symbols, name) != nil {
+			t.Errorf("symbol %q should be ignored (inside comment), but was extracted", name)
+		}
+	}
+}
+
+func TestScanKotlin_IgnoresStringLiterals(t *testing.T) {
+	path, content := loadFixture(t, "edge_cases.kt")
+	idx := ScanKotlin(path, content)
+
+	forbidden := []string{"FakeClass", "fakeFn", "TripleQuotedFake", "anotherFake"}
+	for _, name := range forbidden {
+		if findSymbol(idx.Symbols, name) != nil {
+			t.Errorf("symbol %q should be ignored (inside string literal), but was extracted", name)
+		}
+	}
+}
+
+func TestScanKotlin_UnclosedBlockCommentAtEOF(t *testing.T) {
+	// Input ends mid block-comment. Scanner must:
+	//  - Not panic / not loop infinitely.
+	//  - Treat everything inside the unclosed comment as stripped (no symbols extracted).
+	//  - Return the FileIndex without error (no error channel; just verify it returns).
+	src := []byte(`package x
+
+class RealClass {}
+
+/* unclosed comment from here to EOF
+class FakeClass {}
+fun fakeFn() {}`)
+
+	idx := ScanKotlin("frag.kt", src)
+
+	names := symbolNames(idx.Symbols)
+	if !contains(names, "RealClass") {
+		t.Errorf("expected RealClass to be extracted, got %v", names)
+	}
+	for _, forbidden := range []string{"FakeClass", "fakeFn"} {
+		if contains(names, forbidden) {
+			t.Errorf("symbol %q must NOT appear (inside unclosed block comment), got %v", forbidden, names)
+		}
+	}
+}
+
+func TestScanKotlin_HandlesGenerics(t *testing.T) {
+	path, content := loadFixture(t, "edge_cases.kt")
+	idx := ScanKotlin(path, content)
+
+	if findSymbol(idx.Symbols, "transform") == nil {
+		t.Errorf("expected generic function 'transform' to be extracted; got: %v", symbolNames(idx.Symbols))
+	}
+}
+
+func TestScanKotlin_HandlesExtensionFunctions(t *testing.T) {
+	path, content := loadFixture(t, "edge_cases.kt")
+	idx := ScanKotlin(path, content)
+
+	if findSymbol(idx.Symbols, "extensionFn") == nil {
+		t.Errorf("expected extension function 'extensionFn' to be extracted; got: %v", symbolNames(idx.Symbols))
+	}
+}
+
+func TestScanKotlin_HandlesNestedTypes(t *testing.T) {
+	path, content := loadFixture(t, "edge_cases.kt")
+	idx := ScanKotlin(path, content)
+
+	outer := findSymbol(idx.Symbols, "Outer")
+	if outer == nil {
+		t.Fatalf("expected 'Outer' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if outer.Container != "" {
+		t.Errorf("Outer.Container should be empty, got %q", outer.Container)
+	}
+
+	inner := findSymbol(idx.Symbols, "Inner")
+	if inner == nil {
+		t.Fatalf("expected 'Inner' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if inner.Container != "Outer" {
+		t.Errorf("Inner.Container: want Outer, got %q", inner.Container)
+	}
+
+	innerMethod := findSymbol(idx.Symbols, "innerMethod")
+	if innerMethod == nil {
+		t.Fatalf("expected 'innerMethod' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if innerMethod.Container != "Inner" {
+		t.Errorf("innerMethod.Container: want Inner, got %q", innerMethod.Container)
+	}
+}
+
+func TestScanKotlin_HandlesAnnotations(t *testing.T) {
+	path, content := loadFixture(t, "edge_cases.kt")
+	idx := ScanKotlin(path, content)
+
+	if findSymbol(idx.Symbols, "ComposableScreen") == nil {
+		t.Errorf("expected 'ComposableScreen' (annotated function) to be extracted; got: %v", symbolNames(idx.Symbols))
+	}
+}
+
+func TestScanKotlin_LineCount(t *testing.T) {
+	data, err := os.ReadFile("testdata/kotlin/basic.kt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := bytes.Count(data, []byte("\n"))
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		expected++
+	}
+	idx := ScanKotlin("basic.kt", data)
+	if idx.Lines != expected {
+		t.Errorf("Lines = %d, want %d", idx.Lines, expected)
+	}
+}
+
+func TestScanKotlin_PathSetVerbatim(t *testing.T) {
+	idx := ScanKotlin("custom/path.kt", []byte("class X {}"))
+	if idx.Path != "custom/path.kt" {
+		t.Errorf("Path: want %q, got %q", "custom/path.kt", idx.Path)
+	}
+}

--- a/cli/internal/graph/model.go
+++ b/cli/internal/graph/model.go
@@ -1,0 +1,41 @@
+// Package graph implements the MobiAI semantic code index: a lightweight
+// representation of mobile codebases (Kotlin, Swift) used by the CLI to power
+// fast symbol/import queries without a full language server.
+package graph
+
+import "time"
+
+// IndexVersion is the current schema version of the persisted Graph index.
+// Bumped when the on-disk JSON shape changes in a non-backwards-compatible way.
+const IndexVersion = 1
+
+// Index is the root document of the Graph: a snapshot of every scanned file
+// under Root at GeneratedAt.
+type Index struct {
+	Version     int         `json:"version"`
+	GeneratedAt time.Time   `json:"generatedAt"`
+	Root        string      `json:"root"`
+	Files       []FileIndex `json:"files"`
+}
+
+// FileIndex captures the symbols and imports discovered in a single source
+// file. Path is repo-relative (relative to Index.Root).
+type FileIndex struct {
+	Path     string   `json:"path"`
+	Language string   `json:"language"`
+	Lines    int      `json:"lines"`
+	Imports  []string `json:"imports"`
+	Symbols  []Symbol `json:"symbols"`
+}
+
+// Symbol is a top-level or nested declaration extracted from a source file.
+// Kind values are platform-specific tags (e.g. "class", "fun", "struct",
+// "protocol"). Container is the enclosing class/struct name when the symbol
+// is nested; empty for top-level declarations.
+type Symbol struct {
+	Name      string   `json:"name"`
+	Kind      string   `json:"kind"`
+	Line      int      `json:"line"`
+	Container string   `json:"container,omitempty"`
+	Modifiers []string `json:"modifiers,omitempty"`
+}

--- a/cli/internal/graph/model_test.go
+++ b/cli/internal/graph/model_test.go
@@ -1,0 +1,129 @@
+package graph
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIndexVersion_IsOne(t *testing.T) {
+	if IndexVersion != 1 {
+		t.Fatalf("IndexVersion = %d, want 1", IndexVersion)
+	}
+}
+
+func TestIndex_RoundTripJSON(t *testing.T) {
+	generated := time.Date(2026, time.May, 23, 12, 30, 45, 0, time.UTC)
+	original := Index{
+		Version:     IndexVersion,
+		GeneratedAt: generated,
+		Root:        "/abs/path/to/project",
+		Files: []FileIndex{
+			{
+				Path:     "app/src/main/kotlin/Main.kt",
+				Language: "kotlin",
+				Lines:    42,
+				Imports:  []string{"kotlinx.coroutines.flow.Flow"},
+				Symbols: []Symbol{
+					{
+						Name:      "MainViewModel",
+						Kind:      "class",
+						Line:      10,
+						Container: "Main",
+						Modifiers: []string{"public", "final"},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded Index
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Version != original.Version {
+		t.Errorf("Version = %d, want %d", decoded.Version, original.Version)
+	}
+	if !decoded.GeneratedAt.Equal(original.GeneratedAt) {
+		t.Errorf("GeneratedAt = %v, want %v", decoded.GeneratedAt, original.GeneratedAt)
+	}
+	if decoded.Root != original.Root {
+		t.Errorf("Root = %q, want %q", decoded.Root, original.Root)
+	}
+	if len(decoded.Files) != 1 {
+		t.Fatalf("Files length = %d, want 1", len(decoded.Files))
+	}
+
+	gotFile := decoded.Files[0]
+	wantFile := original.Files[0]
+	if gotFile.Path != wantFile.Path {
+		t.Errorf("Path = %q, want %q", gotFile.Path, wantFile.Path)
+	}
+	if gotFile.Language != wantFile.Language {
+		t.Errorf("Language = %q, want %q", gotFile.Language, wantFile.Language)
+	}
+	if gotFile.Lines != wantFile.Lines {
+		t.Errorf("Lines = %d, want %d", gotFile.Lines, wantFile.Lines)
+	}
+	if len(gotFile.Imports) != 1 || gotFile.Imports[0] != "kotlinx.coroutines.flow.Flow" {
+		t.Errorf("Imports = %v, want [kotlinx.coroutines.flow.Flow]", gotFile.Imports)
+	}
+	if len(gotFile.Symbols) != 1 {
+		t.Fatalf("Symbols length = %d, want 1", len(gotFile.Symbols))
+	}
+
+	gotSym := gotFile.Symbols[0]
+	wantSym := wantFile.Symbols[0]
+	if gotSym.Name != wantSym.Name {
+		t.Errorf("Symbol.Name = %q, want %q", gotSym.Name, wantSym.Name)
+	}
+	if gotSym.Kind != wantSym.Kind {
+		t.Errorf("Symbol.Kind = %q, want %q", gotSym.Kind, wantSym.Kind)
+	}
+	if gotSym.Line != wantSym.Line {
+		t.Errorf("Symbol.Line = %d, want %d", gotSym.Line, wantSym.Line)
+	}
+	if gotSym.Container != wantSym.Container {
+		t.Errorf("Symbol.Container = %q, want %q", gotSym.Container, wantSym.Container)
+	}
+	if len(gotSym.Modifiers) != 2 || gotSym.Modifiers[0] != "public" || gotSym.Modifiers[1] != "final" {
+		t.Errorf("Symbol.Modifiers = %v, want [public final]", gotSym.Modifiers)
+	}
+}
+
+func TestSymbol_OmitEmpty(t *testing.T) {
+	sym := Symbol{
+		Name: "doThing",
+		Kind: "fun",
+		Line: 5,
+	}
+
+	data, err := json.Marshal(&sym)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(data)
+
+	if strings.Contains(out, "container") {
+		t.Errorf("expected no \"container\" key in JSON, got: %s", out)
+	}
+	if strings.Contains(out, "modifiers") {
+		t.Errorf("expected no \"modifiers\" key in JSON, got: %s", out)
+	}
+	if !strings.Contains(out, `"name":"doThing"`) {
+		t.Errorf("expected name field in JSON, got: %s", out)
+	}
+	if !strings.Contains(out, `"kind":"fun"`) {
+		t.Errorf("expected kind field in JSON, got: %s", out)
+	}
+	if !strings.Contains(out, `"line":5`) {
+		t.Errorf("expected line field in JSON, got: %s", out)
+	}
+}

--- a/cli/internal/graph/query.go
+++ b/cli/internal/graph/query.go
@@ -1,0 +1,243 @@
+package graph
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// SearchHit is a single hit returned by Search.
+type SearchHit struct {
+	Symbol   Symbol
+	File     string // FileIndex.Path of the symbol's home file
+	Language string // FileIndex.Language
+	Score    int    // higher = better; ranking: exact match > prefix > substring
+}
+
+// Search looks up symbols by name in the index. Matching is case-insensitive
+// substring; ranking is: exact case-insensitive match (score 3) > prefix
+// match (score 2) > substring match (score 1). Ties broken by File then Line.
+// Empty term returns nil.
+func Search(idx *Index, term string) []SearchHit {
+	if idx == nil || term == "" {
+		return nil
+	}
+	needle := strings.ToLower(term)
+
+	var hits []SearchHit
+	for _, file := range idx.Files {
+		for _, sym := range file.Symbols {
+			name := strings.ToLower(sym.Name)
+			score := 0
+			switch {
+			case name == needle:
+				score = 3
+			case strings.HasPrefix(name, needle):
+				score = 2
+			case strings.Contains(name, needle):
+				score = 1
+			}
+			if score == 0 {
+				continue
+			}
+			hits = append(hits, SearchHit{
+				Symbol:   sym,
+				File:     file.Path,
+				Language: file.Language,
+				Score:    score,
+			})
+		}
+	}
+
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		if hits[i].File != hits[j].File {
+			return hits[i].File < hits[j].File
+		}
+		return hits[i].Symbol.Line < hits[j].Symbol.Line
+	})
+
+	return hits
+}
+
+// CallerHit is a textual occurrence of a symbol name in a file other than
+// (or other than the line of) its definition.
+type CallerHit struct {
+	File    string // FileIndex.Path
+	Line    int    // 1-indexed
+	Snippet string // the raw line, trimmed of trailing whitespace
+}
+
+// Callers returns textual references to a symbol name across the index's
+// files. It reads each file under root (using FileIndex.Path joined to root)
+// and looks for the symbol name as a whole word (\b<name>\b). Definition
+// lines of the SAME name are excluded (a line whose definition Symbol.Line
+// matches). Returns hits sorted by File then Line.
+//
+// If a file fails to read, that file is skipped silently — Callers is
+// best-effort and never returns a partial-failure error.
+func Callers(idx *Index, root, symbol string) []CallerHit {
+	if idx == nil || symbol == "" {
+		return nil
+	}
+
+	re, err := regexp.Compile(`\b` + regexp.QuoteMeta(symbol) + `\b`)
+	if err != nil {
+		return nil
+	}
+
+	// Build set of definition (file, line) pairs to exclude.
+	type fileLine struct {
+		file string
+		line int
+	}
+	defLines := make(map[fileLine]struct{})
+	for _, file := range idx.Files {
+		for _, sym := range file.Symbols {
+			if sym.Name == symbol {
+				defLines[fileLine{file.Path, sym.Line}] = struct{}{}
+			}
+		}
+	}
+
+	var hits []CallerHit
+	for _, file := range idx.Files {
+		abs := filepath.Join(root, filepath.FromSlash(file.Path))
+		f, err := os.Open(abs)
+		if err != nil {
+			continue
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		lineNo := 0
+		for scanner.Scan() {
+			lineNo++
+			line := scanner.Text()
+			if !re.MatchString(line) {
+				continue
+			}
+			if _, isDef := defLines[fileLine{file.Path, lineNo}]; isDef {
+				continue
+			}
+			hits = append(hits, CallerHit{
+				File:    file.Path,
+				Line:    lineNo,
+				Snippet: strings.TrimRight(line, " \t\r\n"),
+			})
+		}
+		f.Close()
+	}
+
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].File != hits[j].File {
+			return hits[i].File < hits[j].File
+		}
+		return hits[i].Line < hits[j].Line
+	})
+
+	return hits
+}
+
+// FileHit is a file scored by relevance to a free-form task description.
+type FileHit struct {
+	File     string
+	Language string
+	Score    int // sum of token-symbol-name matches; ties broken by File
+}
+
+// contextStopwords is the small stopword list dropped during tokenization.
+var contextStopwords = map[string]struct{}{
+	"the":  {},
+	"and":  {},
+	"for":  {},
+	"with": {},
+	"from": {},
+	"into": {},
+	"que":  {},
+	"con":  {},
+	"para": {},
+	"por":  {},
+	"los":  {},
+	"las":  {},
+}
+
+// reContextSplit splits a task string on any non-alphanumeric (Unicode-aware)
+// run. Compiled once at package load.
+var reContextSplit = regexp.MustCompile(`[^\p{L}\p{N}]+`)
+
+// tokenizeContext lowercases task, splits on non-alphanumerics, then drops
+// tokens shorter than 3 chars and stopwords. Duplicates are removed.
+func tokenizeContext(task string) []string {
+	lower := strings.ToLower(task)
+	raw := reContextSplit.Split(lower, -1)
+	seen := make(map[string]struct{})
+	var tokens []string
+	for _, t := range raw {
+		if len(t) < 3 {
+			continue
+		}
+		if _, stop := contextStopwords[t]; stop {
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		tokens = append(tokens, t)
+	}
+	return tokens
+}
+
+// Context tokenizes the task string (split on whitespace and punctuation,
+// lowercase, drop tokens shorter than 3 chars and common stopwords), then
+// scores each file by counting how many of its Symbols' names contain any
+// token (case-insensitive substring). Files with score 0 are excluded.
+// Returns up to maxResults hits; if maxResults <= 0, returns all positive
+// hits. Sort by Score desc, then File asc.
+func Context(idx *Index, task string, maxResults int) []FileHit {
+	if idx == nil {
+		return nil
+	}
+	tokens := tokenizeContext(task)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	var hits []FileHit
+	for _, file := range idx.Files {
+		score := 0
+		for _, sym := range file.Symbols {
+			lname := strings.ToLower(sym.Name)
+			for _, tok := range tokens {
+				if strings.Contains(lname, tok) {
+					score++
+				}
+			}
+		}
+		if score == 0 {
+			continue
+		}
+		hits = append(hits, FileHit{
+			File:     file.Path,
+			Language: file.Language,
+			Score:    score,
+		})
+	}
+
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		return hits[i].File < hits[j].File
+	})
+
+	if maxResults > 0 && len(hits) > maxResults {
+		hits = hits[:maxResults]
+	}
+	return hits
+}

--- a/cli/internal/graph/query_test.go
+++ b/cli/internal/graph/query_test.go
@@ -1,0 +1,294 @@
+package graph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// -- Search ---------------------------------------------------------------
+
+func TestSearch_RanksExactBeforeSubstring(t *testing.T) {
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "a.kt", Language: "kotlin", Symbols: []Symbol{{Name: "Login", Kind: "class", Line: 1}}},
+			{Path: "b.kt", Language: "kotlin", Symbols: []Symbol{{Name: "LoginViewModel", Kind: "class", Line: 1}}},
+			{Path: "c.kt", Language: "kotlin", Symbols: []Symbol{{Name: "helloLogin", Kind: "fun", Line: 1}}},
+		},
+	}
+	hits := Search(idx, "Login")
+	if len(hits) != 3 {
+		t.Fatalf("want 3 hits, got %d", len(hits))
+	}
+	if hits[0].Symbol.Name != "Login" || hits[0].Score != 3 {
+		t.Errorf("hit[0]: got name=%q score=%d, want Login/3", hits[0].Symbol.Name, hits[0].Score)
+	}
+	if hits[1].Symbol.Name != "LoginViewModel" || hits[1].Score != 2 {
+		t.Errorf("hit[1]: got name=%q score=%d, want LoginViewModel/2", hits[1].Symbol.Name, hits[1].Score)
+	}
+	if hits[2].Symbol.Name != "helloLogin" || hits[2].Score != 1 {
+		t.Errorf("hit[2]: got name=%q score=%d, want helloLogin/1", hits[2].Symbol.Name, hits[2].Score)
+	}
+	if hits[0].File != "a.kt" || hits[0].Language != "kotlin" {
+		t.Errorf("hit[0]: file=%q lang=%q", hits[0].File, hits[0].Language)
+	}
+}
+
+func TestSearch_CaseInsensitive(t *testing.T) {
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "b.kt", Language: "kotlin", Symbols: []Symbol{{Name: "LoginViewModel", Kind: "class", Line: 1}}},
+		},
+	}
+	hits := Search(idx, "loginVIEWMODEL")
+	if len(hits) != 1 {
+		t.Fatalf("want 1 hit, got %d", len(hits))
+	}
+	if hits[0].Score != 3 {
+		t.Errorf("want score 3 (exact case-insensitive), got %d", hits[0].Score)
+	}
+}
+
+func TestSearch_EmptyTerm(t *testing.T) {
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "a.kt", Symbols: []Symbol{{Name: "Foo", Line: 1}}},
+		},
+	}
+	if got := Search(idx, ""); got != nil {
+		t.Errorf("want nil, got %v", got)
+	}
+}
+
+func TestSearch_NilIndex(t *testing.T) {
+	if got := Search(nil, "x"); got != nil {
+		t.Errorf("want nil, got %v", got)
+	}
+}
+
+func TestSearch_TieBreakByFileThenLine(t *testing.T) {
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "a.kt", Language: "kotlin", Symbols: []Symbol{
+				{Name: "Foo", Kind: "class", Line: 10},
+				{Name: "Foo", Kind: "class", Line: 5},
+			}},
+			{Path: "b.kt", Language: "kotlin", Symbols: []Symbol{
+				{Name: "Foo", Kind: "class", Line: 1},
+			}},
+		},
+	}
+	hits := Search(idx, "Foo")
+	if len(hits) != 3 {
+		t.Fatalf("want 3 hits, got %d", len(hits))
+	}
+	if hits[0].File != "a.kt" || hits[0].Symbol.Line != 5 {
+		t.Errorf("hit[0]: %s:%d, want a.kt:5", hits[0].File, hits[0].Symbol.Line)
+	}
+	if hits[1].File != "a.kt" || hits[1].Symbol.Line != 10 {
+		t.Errorf("hit[1]: %s:%d, want a.kt:10", hits[1].File, hits[1].Symbol.Line)
+	}
+	if hits[2].File != "b.kt" || hits[2].Symbol.Line != 1 {
+		t.Errorf("hit[2]: %s:%d, want b.kt:1", hits[2].File, hits[2].Symbol.Line)
+	}
+}
+
+// -- Callers --------------------------------------------------------------
+
+func TestCallers_FindsReferences(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.kt"), "class Foo {}\n")
+	writeFile(t, filepath.Join(root, "b.kt"), "fun bar() {\n    val x = Foo()\n    val y = Foo\n}\n")
+
+	idx, err := Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	hits := Callers(idx, root, "Foo")
+	if len(hits) != 2 {
+		t.Fatalf("want 2 hits, got %d: %+v", len(hits), hits)
+	}
+	for _, h := range hits {
+		if h.File != "b.kt" {
+			t.Errorf("unexpected file in hit: %q", h.File)
+		}
+	}
+	if hits[0].Line != 2 || hits[1].Line != 3 {
+		t.Errorf("lines: got %d,%d want 2,3", hits[0].Line, hits[1].Line)
+	}
+	if hits[0].Snippet != "    val x = Foo()" {
+		t.Errorf("snippet[0]: %q", hits[0].Snippet)
+	}
+	if hits[1].Snippet != "    val y = Foo" {
+		t.Errorf("snippet[1]: %q", hits[1].Snippet)
+	}
+}
+
+func TestCallers_ExcludesDefinitionLine(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.kt"), "class Foo {}\n// usage of Foo\n")
+
+	idx, err := Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	hits := Callers(idx, root, "Foo")
+	if len(hits) != 1 {
+		t.Fatalf("want 1 hit (comment line only), got %d: %+v", len(hits), hits)
+	}
+	if hits[0].Line != 2 {
+		t.Errorf("want line 2 (comment), got %d", hits[0].Line)
+	}
+}
+
+func TestCallers_WholeWordOnly(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "b.kt"), "val a = Foobar\nval b = Foo()\n")
+
+	idx, err := Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	hits := Callers(idx, root, "Foo")
+	if len(hits) != 1 {
+		t.Fatalf("want 1 hit, got %d: %+v", len(hits), hits)
+	}
+	if hits[0].Line != 2 {
+		t.Errorf("want line 2, got %d", hits[0].Line)
+	}
+}
+
+func TestCallers_NilIndex(t *testing.T) {
+	if got := Callers(nil, "/tmp", "x"); got != nil {
+		t.Errorf("want nil, got %v", got)
+	}
+}
+
+func TestCallers_MissingFileSkipped(t *testing.T) {
+	root := t.TempDir()
+	idx := &Index{
+		Root: root,
+		Files: []FileIndex{
+			{Path: "does/not/exist.kt", Language: "kotlin"},
+		},
+	}
+	hits := Callers(idx, root, "Foo")
+	if hits != nil && len(hits) != 0 {
+		t.Errorf("want no hits, got %+v", hits)
+	}
+}
+
+// -- Context --------------------------------------------------------------
+
+func TestContext_RanksByTokenOverlap(t *testing.T) {
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "login.kt", Language: "kotlin", Symbols: []Symbol{
+				{Name: "LoginViewModel"}, {Name: "LoginUseCase"},
+			}},
+			{Path: "logout.kt", Language: "kotlin", Symbols: []Symbol{
+				{Name: "LogoutViewModel"},
+			}},
+			{Path: "unrelated.kt", Language: "kotlin", Symbols: []Symbol{
+				{Name: "WeatherWidget"},
+			}},
+		},
+	}
+	hits := Context(idx, "fix login bug", 0)
+	if len(hits) != 1 {
+		t.Fatalf("want 1 hit, got %d: %+v", len(hits), hits)
+	}
+	if hits[0].File != "login.kt" || hits[0].Score != 2 {
+		t.Errorf("got %s score=%d, want login.kt score=2", hits[0].File, hits[0].Score)
+	}
+}
+
+func TestContext_TokenizesProperly(t *testing.T) {
+	// Tokens after tokenization of "Fix the login-flow & navigation":
+	//   {"fix", "login", "flow", "navigation"} ("the" dropped as stopword).
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "fix.kt", Symbols: []Symbol{{Name: "Fixer"}}},
+			{Path: "login.kt", Symbols: []Symbol{{Name: "LoginPage"}}},
+			{Path: "flow.kt", Symbols: []Symbol{{Name: "FlowController"}}},
+			{Path: "nav.kt", Symbols: []Symbol{{Name: "NavigationStack"}}},
+			{Path: "the.kt", Symbols: []Symbol{{Name: "TheThing"}}}, // "the" is stopword
+			{Path: "noise.kt", Symbols: []Symbol{{Name: "Unrelated"}}},
+		},
+	}
+	hits := Context(idx, "Fix the login-flow & navigation", 0)
+	// Expect 4 hits: fix.kt, flow.kt, login.kt, nav.kt (sorted by Score desc then File asc).
+	files := map[string]bool{}
+	for _, h := range hits {
+		files[h.File] = true
+	}
+	want := []string{"fix.kt", "login.kt", "flow.kt", "nav.kt"}
+	for _, w := range want {
+		if !files[w] {
+			t.Errorf("missing expected file %q in hits %+v", w, hits)
+		}
+	}
+	if files["the.kt"] {
+		t.Errorf("the.kt should not match — 'the' is a stopword")
+	}
+	if files["noise.kt"] {
+		t.Errorf("noise.kt should not match")
+	}
+}
+
+func TestContext_DropsStopwordsAndShortTokens(t *testing.T) {
+	// Tokens after tokenization of "fix the los con bug":
+	//   {"fix", "bug"} ("the", "los", "con" are stopwords).
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "fix.kt", Symbols: []Symbol{{Name: "Fixer"}}},
+			{Path: "bug.kt", Symbols: []Symbol{{Name: "Bugfix"}}},
+			{Path: "the.kt", Symbols: []Symbol{{Name: "TheThing"}}},
+			{Path: "los.kt", Symbols: []Symbol{{Name: "LosFoo"}}},
+			{Path: "con.kt", Symbols: []Symbol{{Name: "ConBar"}}},
+		},
+	}
+	hits := Context(idx, "fix the los con bug", 0)
+	files := map[string]bool{}
+	for _, h := range hits {
+		files[h.File] = true
+	}
+	if !files["fix.kt"] || !files["bug.kt"] {
+		t.Errorf("expected fix.kt and bug.kt in hits, got %+v", hits)
+	}
+	if files["the.kt"] || files["los.kt"] || files["con.kt"] {
+		t.Errorf("stopword files should not match: %+v", hits)
+	}
+}
+
+func TestContext_MaxResults(t *testing.T) {
+	// Each file has a symbol containing "widget"; with task "widget",
+	// each file scores 1.
+	idx := &Index{
+		Files: []FileIndex{
+			{Path: "a.kt", Symbols: []Symbol{{Name: "WidgetA"}}},
+			{Path: "b.kt", Symbols: []Symbol{{Name: "WidgetB"}}},
+			{Path: "c.kt", Symbols: []Symbol{{Name: "WidgetC"}}},
+			{Path: "d.kt", Symbols: []Symbol{{Name: "WidgetD"}}},
+			{Path: "e.kt", Symbols: []Symbol{{Name: "WidgetE"}}},
+		},
+	}
+	if got := len(Context(idx, "widget", 2)); got != 2 {
+		t.Errorf("max=2: got %d", got)
+	}
+	if got := len(Context(idx, "widget", 0)); got != 5 {
+		t.Errorf("max=0 (all): got %d", got)
+	}
+}
+
+func TestContext_NilIndex(t *testing.T) {
+	if got := Context(nil, "anything", 0); got != nil {
+		t.Errorf("want nil, got %v", got)
+	}
+}
+
+// Sanity: ensure writeFile from indexer_test.go is reachable (compile-time).
+var _ = os.WriteFile

--- a/cli/internal/graph/storage.go
+++ b/cli/internal/graph/storage.go
@@ -1,0 +1,72 @@
+package graph
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Write serializes idx to path atomically: writes to <path>.tmp, fsyncs, then
+// renames over the destination. Parent directories are created if needed and
+// the JSON is indented with two spaces for diff-friendly storage.
+func Write(path string, idx *Index) error {
+	if idx == nil {
+		return fmt.Errorf("índice nulo")
+	}
+
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return fmt.Errorf("serializar índice: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("crear directorio padre: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("crear archivo temporal: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("escribir archivo temporal: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("sync archivo temporal: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("cerrar archivo temporal: %w", err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("renombrar archivo temporal: %w", err)
+	}
+	return nil
+}
+
+// Read loads and unmarshals an Index from path. It returns an error if the
+// file cannot be read, the JSON is malformed, or the stored Version does not
+// match IndexVersion (on-disk format incompatibility).
+func Read(path string) (*Index, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("leer índice: %w", err)
+	}
+
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("parsear índice: %w", err)
+	}
+
+	if idx.Version != IndexVersion {
+		return nil, fmt.Errorf("versión del índice incompatible: %d (esperado %d)", idx.Version, IndexVersion)
+	}
+	return &idx, nil
+}

--- a/cli/internal/graph/storage_test.go
+++ b/cli/internal/graph/storage_test.go
@@ -1,0 +1,172 @@
+package graph
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleIndex() *Index {
+	return &Index{
+		Version:     IndexVersion,
+		GeneratedAt: time.Date(2026, time.May, 23, 12, 30, 45, 0, time.UTC),
+		Root:        "/abs/path/to/project",
+		Files: []FileIndex{
+			{
+				Path:     "app/src/main/kotlin/Main.kt",
+				Language: "kotlin",
+				Lines:    42,
+				Imports:  []string{"kotlinx.coroutines.flow.Flow"},
+				Symbols: []Symbol{
+					{
+						Name:      "MainViewModel",
+						Kind:      "class",
+						Line:      10,
+						Container: "Main",
+						Modifiers: []string{"public", "final"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestStorage_WriteThenRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.json")
+
+	original := sampleIndex()
+	if err := Write(path, original); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	decoded, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if decoded.Version != original.Version {
+		t.Errorf("Version = %d, want %d", decoded.Version, original.Version)
+	}
+	if !decoded.GeneratedAt.Equal(original.GeneratedAt) {
+		t.Errorf("GeneratedAt = %v, want %v", decoded.GeneratedAt, original.GeneratedAt)
+	}
+	if decoded.Root != original.Root {
+		t.Errorf("Root = %q, want %q", decoded.Root, original.Root)
+	}
+	if len(decoded.Files) != 1 {
+		t.Fatalf("Files length = %d, want 1", len(decoded.Files))
+	}
+
+	gotFile := decoded.Files[0]
+	wantFile := original.Files[0]
+	if gotFile.Path != wantFile.Path {
+		t.Errorf("File.Path = %q, want %q", gotFile.Path, wantFile.Path)
+	}
+	if gotFile.Language != wantFile.Language {
+		t.Errorf("File.Language = %q, want %q", gotFile.Language, wantFile.Language)
+	}
+	if gotFile.Lines != wantFile.Lines {
+		t.Errorf("File.Lines = %d, want %d", gotFile.Lines, wantFile.Lines)
+	}
+	if len(gotFile.Imports) != 1 || gotFile.Imports[0] != "kotlinx.coroutines.flow.Flow" {
+		t.Errorf("File.Imports = %v", gotFile.Imports)
+	}
+	if len(gotFile.Symbols) != 1 {
+		t.Fatalf("File.Symbols length = %d, want 1", len(gotFile.Symbols))
+	}
+
+	gotSym := gotFile.Symbols[0]
+	wantSym := wantFile.Symbols[0]
+	if gotSym.Name != wantSym.Name || gotSym.Kind != wantSym.Kind || gotSym.Line != wantSym.Line {
+		t.Errorf("Symbol = %+v, want %+v", gotSym, wantSym)
+	}
+	if gotSym.Container != wantSym.Container {
+		t.Errorf("Symbol.Container = %q, want %q", gotSym.Container, wantSym.Container)
+	}
+	if len(gotSym.Modifiers) != 2 || gotSym.Modifiers[0] != "public" || gotSym.Modifiers[1] != "final" {
+		t.Errorf("Symbol.Modifiers = %v", gotSym.Modifiers)
+	}
+}
+
+func TestStorage_WriteCreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c", "index.json")
+
+	if err := Write(path, sampleIndex()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s, got: %v", path, err)
+	}
+}
+
+func TestStorage_WriteIsAtomic_NoLeftoverTmp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.json")
+
+	if err := Write(path, sampleIndex()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("expected no leftover tmp file at %s, stat err = %v", tmpPath, err)
+	}
+
+	// Also verify no stray tmp-* files (in case implementation uses CreateTemp).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "index.json" {
+			continue
+		}
+		if strings.Contains(name, ".tmp") {
+			t.Errorf("leftover tmp artifact found: %s", name)
+		}
+	}
+}
+
+func TestStorage_ReadVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.json")
+
+	bogus := `{
+  "version": 999,
+  "generatedAt": "2026-05-23T12:30:45Z",
+  "root": "/x",
+  "files": []
+}`
+	if err := os.WriteFile(path, []byte(bogus), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("expected error for version mismatch, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "999") {
+		t.Errorf("error message %q should mention 999", msg)
+	}
+	if !strings.Contains(msg, fmt.Sprintf("%d", IndexVersion)) {
+		t.Errorf("error message %q should mention IndexVersion (%d)", msg, IndexVersion)
+	}
+}
+
+func TestStorage_ReadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/cli/internal/graph/swift.go
+++ b/cli/internal/graph/swift.go
@@ -1,0 +1,236 @@
+package graph
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+)
+
+// Compiled regexes used by ScanSwift. Defined at package level so they are
+// compiled once.
+var (
+	// reSwiftImport matches `import Foundation` or `import Combine.Publishers`.
+	// Single capture group = module path.
+	reSwiftImport = regexp.MustCompile(`^\s*import\s+([\w.]+)\s*$`)
+
+	// reSwiftType matches class/struct/enum/protocol/actor/extension
+	// declarations with optional modifiers (group 1 = modifiers,
+	// group 2 = keyword, group 3 = name).
+	reSwiftType = regexp.MustCompile(`^\s*((?:(?:public|private|fileprivate|internal|open|final)\s+)*)(class|struct|enum|protocol|actor|extension)\s+(\w+)`)
+
+	// reSwiftFunc matches `func foo(...)` or `func foo<T>(...)`.
+	// Group 1 = modifiers, group 2 = function name.
+	// The trailing `[<(]` matches either generic params or the opening paren.
+	reSwiftFunc = regexp.MustCompile(`^\s*((?:(?:public|private|fileprivate|internal|open|static|class|mutating|override|final|nonisolated)\s+)*)func\s+(\w+)\s*[<(]`)
+)
+
+// ScanSwift parses a Swift source file's bytes and returns a FileIndex
+// populated with imports, symbols, language="swift", and line count.
+// The path field is set to the path argument verbatim (caller is responsible
+// for passing a repo-relative path).
+func ScanSwift(path string, content []byte) FileIndex {
+	idx := FileIndex{
+		Path:     path,
+		Language: "swift",
+		Lines:    countLines(content),
+		Imports:  []string{},
+		Symbols:  []Symbol{},
+	}
+
+	stripped := stripSwiftCommentsAndStrings(content)
+	lines := bytes.Split(stripped, []byte("\n"))
+
+	var stack []containerEntry
+	depth := 0
+
+	for i, rawLine := range lines {
+		lineNum := i + 1
+		line := string(rawLine)
+
+		// Imports.
+		if m := reSwiftImport.FindStringSubmatch(line); m != nil {
+			idx.Imports = append(idx.Imports, m[1])
+		}
+
+		// Container at the START of this line is the innermost open
+		// type, if any.
+		container := ""
+		if len(stack) > 0 {
+			container = stack[len(stack)-1].Name
+		}
+
+		// Type declarations (class/struct/enum/protocol/actor/extension).
+		if m := reSwiftType.FindStringSubmatch(line); m != nil {
+			modifiers := splitModifiers(m[1])
+			kind := m[2]
+			name := m[3]
+
+			sym := Symbol{
+				Name:      name,
+				Kind:      kind,
+				Line:      lineNum,
+				Container: container,
+				Modifiers: modifiers,
+			}
+			idx.Symbols = append(idx.Symbols, sym)
+
+			// Push onto the stack so subsequent symbols know their
+			// container. Pop happens when brace depth drops back.
+			stack = append(stack, containerEntry{Name: name, Depth: depth})
+		} else {
+			// Functions (only if line is not a type decl).
+			if m := reSwiftFunc.FindStringSubmatch(line); m != nil {
+				modifiers := splitModifiers(m[1])
+				name := m[2]
+				sym := Symbol{
+					Name:      name,
+					Kind:      "func",
+					Line:      lineNum,
+					Container: container,
+					Modifiers: modifiers,
+				}
+				idx.Symbols = append(idx.Symbols, sym)
+			}
+		}
+
+		// Update brace depth based on this line's braces, then pop
+		// any containers whose body has closed.
+		opens := strings.Count(line, "{")
+		closes := strings.Count(line, "}")
+		depth += opens
+		depth -= closes
+
+		for len(stack) > 0 && depth <= stack[len(stack)-1].Depth {
+			stack = stack[:len(stack)-1]
+		}
+	}
+
+	return idx
+}
+
+// stripSwiftCommentsAndStrings walks the bytes once and replaces the contents
+// of line comments, block comments, and string literals with spaces. Newlines
+// inside the stripped regions are preserved so that line numbers match the
+// original. This makes downstream regex matching immune to "class X" appearing
+// inside a comment or string.
+//
+// State machine handles:
+//   - line comments: `// ... \n`
+//   - block comments: `/* ... */`
+//   - double-quoted strings: `"..."` with `\"` escape.
+//   - triple-quoted multiline strings: `"""..."""`
+//
+// This is intentionally a near-copy of stripCommentsAndStrings in kotlin.go:
+// Swift and Kotlin share the same comment and string-literal forms. We keep
+// them separate per task constraints (no shared extraction yet).
+func stripSwiftCommentsAndStrings(content []byte) []byte {
+	out := make([]byte, len(content))
+	copy(out, content)
+
+	const (
+		stateCode = iota
+		stateLineComment
+		stateBlockComment
+		stateString       // "..."
+		stateTripleString // """..."""
+	)
+
+	state := stateCode
+	i := 0
+	n := len(content)
+
+	for i < n {
+		c := content[i]
+
+		switch state {
+		case stateCode:
+			// Triple-quoted string opener.
+			if c == '"' && i+2 < n && content[i+1] == '"' && content[i+2] == '"' {
+				i += 3
+				state = stateTripleString
+				continue
+			}
+			if c == '"' {
+				i++
+				state = stateString
+				continue
+			}
+			if c == '/' && i+1 < n && content[i+1] == '/' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				state = stateLineComment
+				continue
+			}
+			if c == '/' && i+1 < n && content[i+1] == '*' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				state = stateBlockComment
+				continue
+			}
+			i++
+
+		case stateLineComment:
+			if c == '\n' {
+				state = stateCode
+				i++
+				continue
+			}
+			out[i] = ' '
+			i++
+
+		case stateBlockComment:
+			if c == '*' && i+1 < n && content[i+1] == '/' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				state = stateCode
+				continue
+			}
+			if c != '\n' {
+				out[i] = ' '
+			}
+			i++
+
+		case stateString:
+			if c == '\\' && i+1 < n {
+				if content[i+1] != '\n' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					continue
+				}
+				out[i] = ' '
+				i++
+				continue
+			}
+			if c == '"' {
+				i++
+				state = stateCode
+				continue
+			}
+			if c == '\n' {
+				// Unterminated string — bail back to code mode.
+				state = stateCode
+				i++
+				continue
+			}
+			out[i] = ' '
+			i++
+
+		case stateTripleString:
+			if c == '"' && i+2 < n && content[i+1] == '"' && content[i+2] == '"' {
+				i += 3
+				state = stateCode
+				continue
+			}
+			if c != '\n' {
+				out[i] = ' '
+			}
+			i++
+		}
+	}
+
+	return out
+}

--- a/cli/internal/graph/swift_test.go
+++ b/cli/internal/graph/swift_test.go
@@ -1,0 +1,262 @@
+package graph
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadSwiftFixture reads a Swift fixture file from testdata/swift/.
+func loadSwiftFixture(t *testing.T, name string) (string, []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", "swift", name)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", path, err)
+	}
+	return path, content
+}
+
+func TestScanSwift_Basic(t *testing.T) {
+	path, content := loadSwiftFixture(t, "basic.swift")
+	idx := ScanSwift(path, content)
+
+	if idx.Language != "swift" {
+		t.Errorf("expected language=swift, got %q", idx.Language)
+	}
+
+	wantImports := []string{"Foundation", "Combine", "SwiftUI"}
+	if len(idx.Imports) != len(wantImports) {
+		t.Fatalf("expected %d imports, got %d: %v", len(wantImports), len(idx.Imports), idx.Imports)
+	}
+	for i, want := range wantImports {
+		if idx.Imports[i] != want {
+			t.Errorf("imports[%d]: want %q, got %q", i, want, idx.Imports[i])
+		}
+	}
+
+	mustHave := []string{
+		"LoginViewModel", "User", "AuthRepository", "AuthError",
+		"SessionStore", "login", "logout", "authenticate", "clear",
+		"set", "displayName",
+	}
+	for _, name := range mustHave {
+		if findSymbol(idx.Symbols, name) == nil {
+			t.Errorf("expected symbol %q in symbols; got: %v", name, symbolNames(idx.Symbols))
+		}
+	}
+
+	// Extension surfaces with the extended-type name: there must be a
+	// symbol "User" with kind "extension".
+	foundExtUser := false
+	for _, s := range idx.Symbols {
+		if s.Name == "User" && s.Kind == "extension" {
+			foundExtUser = true
+			break
+		}
+	}
+	if !foundExtUser {
+		t.Errorf("expected an extension symbol named \"User\"; got: %v", idx.Symbols)
+	}
+
+	if login := findSymbol(idx.Symbols, "login"); login != nil {
+		if login.Container != "LoginViewModel" {
+			t.Errorf("login.Container: want LoginViewModel, got %q", login.Container)
+		}
+	}
+
+	// SessionStore must be present with Kind == "actor".
+	foundActor := false
+	for _, s := range idx.Symbols {
+		if s.Name == "SessionStore" && s.Kind == "actor" {
+			foundActor = true
+			break
+		}
+	}
+	if !foundActor {
+		t.Errorf("expected SessionStore with Kind=actor; got: %v", idx.Symbols)
+	}
+
+	// The User struct (Kind=="struct") must have empty Container.
+	foundUserStruct := false
+	for _, s := range idx.Symbols {
+		if s.Name == "User" && s.Kind == "struct" {
+			foundUserStruct = true
+			if s.Container != "" {
+				t.Errorf("User struct Container should be empty, got %q", s.Container)
+			}
+		}
+	}
+	if !foundUserStruct {
+		t.Errorf("expected a struct symbol named \"User\"; got: %v", idx.Symbols)
+	}
+}
+
+func TestScanSwift_IgnoresComments(t *testing.T) {
+	path, content := loadSwiftFixture(t, "edge_cases.swift")
+	idx := ScanSwift(path, content)
+
+	forbidden := []string{"NotARealClass", "AlsoNotReal", "alsoIgnoredFn"}
+	for _, name := range forbidden {
+		if findSymbol(idx.Symbols, name) != nil {
+			t.Errorf("symbol %q should be ignored (inside comment), but was extracted", name)
+		}
+	}
+}
+
+func TestScanSwift_IgnoresStringLiterals(t *testing.T) {
+	path, content := loadSwiftFixture(t, "edge_cases.swift")
+	idx := ScanSwift(path, content)
+
+	forbidden := []string{"FakeClass", "fakeFn", "TripleQuotedFake", "anotherFake"}
+	for _, name := range forbidden {
+		if findSymbol(idx.Symbols, name) != nil {
+			t.Errorf("symbol %q should be ignored (inside string literal), but was extracted", name)
+		}
+	}
+}
+
+func TestScanSwift_HandlesGenerics(t *testing.T) {
+	path, content := loadSwiftFixture(t, "edge_cases.swift")
+	idx := ScanSwift(path, content)
+
+	if findSymbol(idx.Symbols, "transform") == nil {
+		t.Errorf("expected generic function 'transform' to be extracted; got: %v", symbolNames(idx.Symbols))
+	}
+}
+
+func TestScanSwift_HandlesNestedTypes(t *testing.T) {
+	path, content := loadSwiftFixture(t, "edge_cases.swift")
+	idx := ScanSwift(path, content)
+
+	outer := findSymbol(idx.Symbols, "Outer")
+	if outer == nil {
+		t.Fatalf("expected 'Outer' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if outer.Container != "" {
+		t.Errorf("Outer.Container should be empty, got %q", outer.Container)
+	}
+
+	inner := findSymbol(idx.Symbols, "Inner")
+	if inner == nil {
+		t.Fatalf("expected 'Inner' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if inner.Container != "Outer" {
+		t.Errorf("Inner.Container: want Outer, got %q", inner.Container)
+	}
+
+	innerMethod := findSymbol(idx.Symbols, "innerMethod")
+	if innerMethod == nil {
+		t.Fatalf("expected 'innerMethod' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if innerMethod.Container != "Inner" {
+		t.Errorf("innerMethod.Container: want Inner, got %q", innerMethod.Container)
+	}
+}
+
+func TestScanSwift_HandlesModifiers(t *testing.T) {
+	path, content := loadSwiftFixture(t, "edge_cases.swift")
+	idx := ScanSwift(path, content)
+
+	finalClass := findSymbol(idx.Symbols, "FinalClass")
+	if finalClass == nil {
+		t.Fatalf("expected 'FinalClass' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if !contains(finalClass.Modifiers, "public") || !contains(finalClass.Modifiers, "final") {
+		t.Errorf("FinalClass.Modifiers should contain public and final, got %v", finalClass.Modifiers)
+	}
+
+	staticFn := findSymbol(idx.Symbols, "staticFn")
+	if staticFn == nil {
+		t.Fatalf("expected 'staticFn' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if !contains(staticFn.Modifiers, "public") || !contains(staticFn.Modifiers, "static") {
+		t.Errorf("staticFn.Modifiers should contain public and static, got %v", staticFn.Modifiers)
+	}
+
+	isolatedFn := findSymbol(idx.Symbols, "isolatedFn")
+	if isolatedFn == nil {
+		t.Fatalf("expected 'isolatedFn' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if !contains(isolatedFn.Modifiers, "nonisolated") {
+		t.Errorf("isolatedFn.Modifiers should contain nonisolated, got %v", isolatedFn.Modifiers)
+	}
+}
+
+func TestScanSwift_HandlesExtensions(t *testing.T) {
+	path, content := loadSwiftFixture(t, "edge_cases.swift")
+	idx := ScanSwift(path, content)
+
+	foundExt := false
+	for _, s := range idx.Symbols {
+		if s.Name == "String" && s.Kind == "extension" {
+			foundExt = true
+			break
+		}
+	}
+	if !foundExt {
+		t.Errorf("expected an extension symbol named \"String\"; got: %v", idx.Symbols)
+	}
+
+	extensionFn := findSymbol(idx.Symbols, "extensionFn")
+	if extensionFn == nil {
+		t.Fatalf("expected 'extensionFn' in symbols; got: %v", symbolNames(idx.Symbols))
+	}
+	if extensionFn.Container != "String" {
+		t.Errorf("extensionFn.Container: want String, got %q", extensionFn.Container)
+	}
+}
+
+func TestScanSwift_HandlesAnnotations(t *testing.T) {
+	path, content := loadSwiftFixture(t, "edge_cases.swift")
+	idx := ScanSwift(path, content)
+
+	if findSymbol(idx.Symbols, "mainActorFn") == nil {
+		t.Errorf("expected 'mainActorFn' (annotated function) to be extracted; got: %v", symbolNames(idx.Symbols))
+	}
+}
+
+func TestScanSwift_UnclosedBlockCommentAtEOF(t *testing.T) {
+	src := []byte(`import Foundation
+
+class RealClass {}
+
+/* unclosed comment from here to EOF
+class FakeClass {}
+func fakeFn() {}`)
+
+	idx := ScanSwift("frag.swift", src)
+
+	names := symbolNames(idx.Symbols)
+	if !contains(names, "RealClass") {
+		t.Errorf("expected RealClass to be extracted, got %v", names)
+	}
+	for _, forbidden := range []string{"FakeClass", "fakeFn"} {
+		if contains(names, forbidden) {
+			t.Errorf("symbol %q must NOT appear (inside unclosed block comment), got %v", forbidden, names)
+		}
+	}
+}
+
+func TestScanSwift_LineCount(t *testing.T) {
+	data, err := os.ReadFile("testdata/swift/basic.swift")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := bytes.Count(data, []byte("\n"))
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		expected++
+	}
+	idx := ScanSwift("basic.swift", data)
+	if idx.Lines != expected {
+		t.Errorf("Lines = %d, want %d", idx.Lines, expected)
+	}
+}
+
+func TestScanSwift_PathSetVerbatim(t *testing.T) {
+	idx := ScanSwift("custom/path.swift", []byte("struct X {}"))
+	if idx.Path != "custom/path.swift" {
+		t.Errorf("Path: want %q, got %q", "custom/path.swift", idx.Path)
+	}
+}

--- a/cli/internal/graph/testdata/kotlin/basic.kt
+++ b/cli/internal/graph/testdata/kotlin/basic.kt
@@ -1,0 +1,30 @@
+package com.mobiai.demo
+
+import com.x.y.Foo
+import kotlinx.coroutines.flow.Flow
+
+class LoginViewModel(private val repo: AuthRepository) {
+    fun login(email: String, password: String): Flow<Result> {
+        return repo.authenticate(email, password)
+    }
+
+    fun logout() {
+        repo.clear()
+    }
+}
+
+object Config {
+    val baseUrl = "https://example.com"
+}
+
+interface AuthRepository {
+    suspend fun authenticate(email: String, password: String): User?
+    fun clear()
+}
+
+data class User(val id: String, val email: String)
+
+sealed class Result {
+    object Success : Result()
+    data class Error(val message: String) : Result()
+}

--- a/cli/internal/graph/testdata/kotlin/edge_cases.kt
+++ b/cli/internal/graph/testdata/kotlin/edge_cases.kt
@@ -1,0 +1,33 @@
+package com.mobiai.demo
+
+import com.x.Y
+
+// class NotARealClass — should be ignored (line comment)
+
+/*
+class AlsoNotReal
+fun alsoIgnoredFn() {}
+*/
+
+class Outer {
+    /* nested block /* not really nested */ comment */
+    private inline fun <T> transform(input: String): T {
+        val literal = "class FakeClass { fun fakeFn() {} }"
+        val multi = """
+            class TripleQuotedFake
+            fun anotherFake()
+        """.trimIndent()
+        return input as T
+    }
+
+    inner class Inner {
+        fun innerMethod() {}
+    }
+}
+
+fun String.extensionFn(): Int = length
+
+suspend fun coroutineFn() {}
+
+@Composable
+public open fun ComposableScreen() {}

--- a/cli/internal/graph/testdata/swift/basic.swift
+++ b/cli/internal/graph/testdata/swift/basic.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Combine
+import SwiftUI
+
+class LoginViewModel: ObservableObject {
+    @Published private(set) var state: LoginState = .idle
+    private let repo: AuthRepository
+
+    init(repo: AuthRepository) {
+        self.repo = repo
+    }
+
+    func login(email: String, password: String) async throws -> User {
+        return try await repo.authenticate(email: email, password: password)
+    }
+
+    func logout() {
+        repo.clear()
+    }
+}
+
+struct User: Identifiable, Codable {
+    let id: String
+    let email: String
+}
+
+protocol AuthRepository {
+    func authenticate(email: String, password: String) async throws -> User
+    func clear()
+}
+
+enum AuthError: Error {
+    case invalidCredentials
+    case network(underlying: Error)
+}
+
+actor SessionStore {
+    private var current: User?
+
+    func set(_ user: User) {
+        current = user
+    }
+}
+
+extension User {
+    func displayName() -> String { email }
+}

--- a/cli/internal/graph/testdata/swift/edge_cases.swift
+++ b/cli/internal/graph/testdata/swift/edge_cases.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+// class NotARealClass — should be ignored (line comment)
+
+/*
+class AlsoNotReal
+func alsoIgnoredFn() {}
+*/
+
+class Outer {
+    /* nested block /* not really */ comment */
+    func transform<T>(input: String) -> T {
+        let literal = "class FakeClass { func fakeFn() {} }"
+        let multi = """
+            class TripleQuotedFake
+            func anotherFake()
+            """
+        return input as! T
+    }
+
+    class Inner {
+        func innerMethod() {}
+    }
+}
+
+extension String {
+    func extensionFn() -> Int { count }
+}
+
+public final class FinalClass {
+    public static func staticFn() {}
+    nonisolated func isolatedFn() {}
+}
+
+@MainActor
+public func mainActorFn() {}

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,83 @@
+# MobiAI Graph
+
+> Exploración semántica del código mobile, local y regenerable. MobiAI Graph entiende apps Android, iOS, KMP, Flutter y React Native.
+
+## Qué es MobiAI Graph
+
+MobiAI Graph es una **capacidad** del agente, no un producto separado: exploración semántica del código mobile sobre un índice local que se regenera bajo demanda. No es un servicio, no es una base de datos remota, no requiere cuenta ni cloud.
+
+Vive en `<repo>/.mobiai/graph/index.json` — local-first, regenerable, sin nube. En V1 cubre **Kotlin** y **Swift**, los dos lenguajes nativos del stack mobile que MobiAI prioriza.
+
+## Skills vs Brain vs Graph
+
+MobiAI tiene tres piezas complementarias. Cada una resuelve un problema distinto:
+
+| Pieza | Qué guarda | Quién la mantiene | Propiedad clave |
+|---|---|---|---|
+| Skills | Cómo trabajar (proceso, flujos) | El equipo MobiAI (en plugins) | Globales, compartidas entre proyectos |
+| Brain | Qué se decidió, qué workarounds hay activos | El usuario del proyecto | Memoria histórica humana, diff-friendly |
+| Graph | Estructura actual del código | Generado automáticamente | Computado, regenerable, no editar a mano |
+
+Las tres son complementarias. Una decisión bien tomada combina las tres: la skill marca el flujo, Brain aporta el contexto histórico, Graph señala dónde vive el código afectado hoy.
+
+## Cómo funciona V1
+
+- Scanners por **regex línea-a-línea** para Kotlin y Swift.
+- Persistencia **JSON plano** en `.mobiai/graph/index.json`.
+- Sin dependencias externas (stdlib Go + `cobra` ya presente en la CLI).
+- Sin watcher: `mobiai graph init` regenera el índice entero.
+- Sin AST, sin resolución de tipos, sin análisis cross-file.
+
+Ejemplo de uso real:
+
+```
+$ mobiai graph init
+✓ Índice generado: /Users/.../proyecto/.mobiai/graph/index.json
+  Archivos: 1
+  Símbolos: 1
+  Kotlin: 1
+  Swift: 0
+
+$ mobiai graph search Login
+app/LoginViewModel.kt:5 class LoginViewModel
+```
+
+El índice es **regenerable**: si los regex evolucionan o el código cambia, basta con volver a correr `mobiai graph init`.
+
+## Lenguajes soportados
+
+| Lenguaje | V1 | Roadmap V2/V3 |
+|---|---|---|
+| Kotlin | ✅ | mejorar precisión con AST |
+| Swift | ✅ | mejorar precisión con AST |
+| Dart (Flutter) | ❌ | V2 |
+| JavaScript / TypeScript (RN) | ❌ | V2 |
+| Java | ❌ | V2 |
+| KMP `expect/actual` semantics | parcial (cada lado se indexa por separado) | V3 |
+
+## Inspiración
+
+La idea de un grafo semántico local para acelerar a los agentes IA no es nueva. [CodeGraph](https://github.com/colbymchenry/codegraph) (TypeScript + tree-sitter + SQLite/FTS5) la popularizó en proyectos web. MobiAI Graph toma esa idea y la lleva al terreno mobile, con stack Go nativo y prioridad en lenguajes y patrones que importan en Android, iOS, KMP, Flutter y React Native.
+
+## Roadmap (futuro, no implementado)
+
+- **V2** (futuro):
+  - Soporte Dart, JavaScript/TypeScript y Java (no implementado).
+  - Watcher incremental — el índice se refresca cuando cambian archivos (no implementado).
+  - Posible migración a tree-sitter como parser si los regex se quedan cortos (decisión pendiente).
+- **V3** (futuro):
+  - Semántica mobile específica: Compose `@Composable` → ViewModel → UseCase → Repository (no implementado).
+  - KMP `expect/actual` mapeado a sus implementaciones por plataforma (no implementado).
+  - Navigation Compose / SwiftUI routes → screens (no implementado).
+  - Hilt / Koin module bindings (no implementado).
+- **V4** (especulativo, sin fecha):
+  - MCP server propio para que clientes IA consulten Graph como tool nativa (no implementado).
+
+Ninguna de estas piezas está disponible hoy. La documentación se actualizará cuando lo estén.
+
+## Política
+
+- MobiAI nunca instala backends externos automáticamente. Graph es Go nativo y vive dentro de la CLI `mobiai`.
+- El índice (`.mobiai/graph/index.json`) es **regenerable**: no es obligatorio commitearlo. Si tu equipo prefiere mantenerlo fuera del repo, gitignorealo sin miedo — no es información crítica.
+- Graph **no reemplaza a Brain**: si una decisión, workaround o convención debe persistir entre cambios de código, va a Brain. Graph solo refleja la estructura actual del código.
+- Cero datos del usuario salen de su máquina. Graph es 100% local.

--- a/plugins/core/skills/mobiai-graph/SKILL.md
+++ b/plugins/core/skills/mobiai-graph/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: mobiai-graph
+description: "Use when the user asks about code impact, call graph, callers/callees, semantic exploration of the mobile codebase, or 'where is X used'. Routes the agent to query MobiAI Graph (mobiai graph search/callers/context) instead of grep/read. Pre-flight checks that .mobiai/graph/index.json exists; if not, suggests `mobiai graph init` without running it."
+license: MIT
+compatibility: [claude-code, cursor, copilot, codex, gemini]
+platforms: [android, ios, kmp, flutter, react-native]
+---
+
+# MobiAI Graph
+
+CodeGraph entiende código. MobiAI Graph entiende apps mobile. Índice semántico per-project del codebase mobile, vive en `<repo>/.mobiai/graph/index.json` — regenerable, complementario a Brain (Brain = memoria humana del proyecto, Graph = estructura computada del código).
+
+## When to invoke this skill
+
+- User asks "where is X used", "impacto de cambiar X", "dónde se usa", "qué llama a Y", "callers/callees".
+- User pide el call graph o quiere explorar la arquitectura del proyecto.
+- User pregunta qué tests están afectados por un cambio.
+- Antes de cambios cross-file no triviales: para acotar el blast radius antes de tocar código.
+- Cuando un fix exige saber qué pantallas / ViewModels / repositorios dependen de un símbolo concreto.
+
+**Skip** cuando el archivo / símbolo ya está identificado, cuando el fix es one-liner, o cuando el output esperado es más grande que lo que devuelve una sola llamada al CLI — en ese caso delegar a un sub-agente Explore.
+
+## Pre-flight
+
+**Verificá una única vez** al inicio de la conversación (o al invocar esta skill por primera vez), no antes de cada subcomando:
+
+1. Verificá que existe `<repo>/.mobiai/graph/index.json`.
+2. Si **no existe**: avisá una sola vez al usuario:
+   > "No encuentro `<repo>/.mobiai/graph/index.json`. Podés crearlo con: `mobiai graph init`"
+   No corras `init` por tu cuenta. Esperá confirmación explícita.
+3. Si **existe pero tiene más de 24h**: mencionalo casualmente y ofrecé re-correr `mobiai graph init` antes de confiar en los resultados. Sólo re-indexá si el usuario lo pide.
+
+`mobiai graph status` muestra la antigüedad del índice y el conteo de símbolos — sirve como check rápido.
+
+## Commands available today
+
+```
+mobiai graph init                  # Indexa el proyecto (Kotlin + Swift en V1)
+mobiai graph status                # Stats del índice y antigüedad
+mobiai graph search <term>         # Lookup de símbolos
+mobiai graph callers <symbol>      # Referencias textuales
+mobiai graph context <task...>     # Archivos relevantes para una tarea
+```
+
+```bash
+# Ambas formas son válidas (Cobra acepta 1+ argumentos posicionales):
+mobiai graph context fix login bug
+mobiai graph context "fix login bug"
+```
+
+Cada uno devuelve output autocontenido. Preferí una llamada por pregunta concreta; no encadenes 5 búsquedas si una sola `context` resuelve el caso.
+
+### Recipes rápidas
+
+```bash
+# Antes de tocar un símbolo cross-file:
+mobiai graph callers AuthRepository
+
+# Para arrancar una feature nueva y entender qué archivos están en juego:
+mobiai graph context "agregar refresh token al flujo de login"
+
+# Para chequear si existe un nombre antes de inventarlo:
+mobiai graph search SessionManager
+
+# Para confirmar que el índice no está stale antes de confiar en callers:
+mobiai graph status
+```
+
+Si vas a hacer varias preguntas seguidas sobre el mismo área, **una sola `context` suele ser más barata** que tres `search` + dos `callers`.
+
+## When to prefer Graph over grep/read
+
+| Pregunta | Herramienta preferida |
+|---|---|
+| "¿Dónde se usa X?" | `mobiai graph callers X` |
+| "¿Qué pantallas tocan este Repository?" | `mobiai graph context "<descripción>"` |
+| "¿Qué clases tienen 'Login' en el nombre?" | `mobiai graph search Login` |
+| "Leer el contenido exacto de Foo.kt" | `Read` (no necesitás el grafo) |
+| "Buscar la string literal 'TODO: fix'" | `grep` / `rg` (no es semántico) |
+
+Regla mental: si la pregunta es **sobre un símbolo** (clase, función, propiedad), Graph. Si es **sobre texto exacto**, grep. Si es **leer un archivo conocido**, Read.
+
+### Anatomía del output
+
+- `search` devuelve nombres de símbolos con el archivo donde están declarados. Útil para confirmar que un nombre existe antes de citarlo.
+- `callers` devuelve la lista de archivos y líneas que **mencionan** el símbolo. Es match textual: filtrá mentalmente los falsos positivos obvios (comentarios, strings).
+- `context` devuelve un set de archivos rankeados por overlap con la descripción de la tarea. Es el punto de entrada típico cuando arrancás un ticket sin saber dónde mirar.
+- `status` devuelve métricas: cantidad de símbolos, archivos indexados, timestamp del último `init`.
+
+## Combinación con Brain
+
+Orden recomendado cuando ambas skills aplican:
+
+1. **Brain primero** — para entender decisiones, convenciones y workarounds activos del proyecto (`mobiai brain context`).
+2. **Graph después** — para descubrir la estructura actual del código que esas decisiones produjeron.
+3. **Acción al final**, respetando ambos.
+
+Ejemplo concreto:
+
+> El usuario pide migrar `LoginViewModel` a otra librería de DI.
+> Brain dice: "decisión activa — usamos Koin, no Hilt, por compatibilidad con KMP".
+> Graph dice: `mobiai graph callers LoginViewModel` → 3 archivos (LoginScreen, LoginNavGraph, LoginViewModelTest); `mobiai graph context "login flow"` → suma LoginUseCase y AuthRepository.
+> Acción: respetar Koin (Brain), tocar exactamente esos archivos (Graph), no inventar refactor más amplio.
+
+## When NOT to use Graph
+
+- Archivo ya identificado y cambio de una sola línea.
+- Búsqueda de string literal, no de símbolo (usá `grep` / `rg`).
+- El índice nunca se generó y el usuario no quiere correr `init`. V1 cubre Kotlin + Swift; en proyectos Flutter/Dart, React Native o web puro el grafo está vacío y no aporta nada.
+- El output esperado es enorme (miles de hits) y va a inflar el contexto — delegar a un subagente Explore con instrucción de devolver sólo el resumen.
+- Tarea puramente de UI / assets / configuración donde el grafo de símbolos no aplica.
+
+## Cómo se enlaza con otras skills MobiAI
+
+Graph es un proveedor de contexto estructural; varias skills de metodología pueden consultarlo sin reemplazarse:
+
+- `mobiai-mobile-debugging` puede usar `callers` / `context` para entender qué se ve afectado por una hipótesis de root cause antes de proponer fix.
+- `mobiai-fix-issue` puede usar `context` para acotar el blast radius del ticket antes de tocar archivos.
+- `mobiai-write-tests` puede usar `callers` para encontrar tests existentes relacionados al símbolo bajo cambio y evitar duplicar cobertura.
+- `mobiai-review-code` puede usar `callers` para evaluar el impacto real de un diff cross-file.
+
+Ninguna de esas skills se modifica desde acá: Graph es opt-in, cada skill decide cuándo llamarlo.
+
+## Limitaciones de V1
+
+Sé honesto sobre lo que Graph **no** hace todavía:
+
+- **Sólo Kotlin y Swift.** Dart, JS/TS, Java puro no se indexan en V1.
+- **Scanners regex, no AST** → posibles falsos positivos en símbolos dentro de strings raros, comentarios multilínea exóticos o macros.
+- **No hay resolución de tipos** → `callers` es match textual de nombre, no análisis de overload ni de shadowing.
+- **`context` es heurística por overlap de tokens**, no búsqueda semántica con embeddings. Funciona bien para tareas con vocabulario que ya aparece en el código; degrada si la descripción es muy abstracta.
+- **El índice no es incremental**: `init` lo regenera entero cada vez. En repos grandes puede tardar.
+
+Cuando una de estas limitaciones aplica al caso, decilo al usuario y caé al método más adecuado (Read directo, grep, o sub-agente Explore).
+
+## Roadmap
+
+Lo siguiente **no está implementado**, es sólo dirección futura — no prometas estas features como disponibles:
+
+- **V2 (planeado, no implementado):** AST real (posiblemente tree-sitter), soporte para más lenguajes (Dart, JS/TS, Java) y watcher incremental para no regenerar el índice entero.
+- **V3 (planeado, no implementado):** semántica mobile-específica — cadenas `Composable → ViewModel → UseCase → Repository`, KMP `expect/actual`, rutas de Compose Navigation, etc.
+- **V4 (planeado, no implementado):** servidor MCP propio para que clientes IA consulten Graph como herramienta nativa (paralelo a `mobiai brain mcp`).
+
+Si el usuario pregunta por algo de este roadmap, dejá claro que hoy no está disponible y, si aplica, sugerí abrir un issue.
+
+## Behavior contract
+
+- Graph es **per-project**. No mezcles resultados entre repos ni asumas que un símbolo del proyecto A existe en el proyecto B.
+- Graph es **complementario** a Brain, a `CLAUDE.md` y a las skills de metodología — nunca las reemplaza.
+- El índice es **regenerable y desechable**. No lo edites a mano: corré `mobiai graph init`.
+- Si un resultado de `callers` o `context` se ve sospechoso (cero hits para algo que claramente existe, o un hit obviamente erróneo), chequeá `mobiai graph status` y considerá re-indexar antes de actuar.

--- a/plugins/core/skills/using-mobiai/SKILL.md
+++ b/plugins/core/skills/using-mobiai/SKILL.md
@@ -75,6 +75,7 @@ Match the user's intent against the rows below. If any row matches even at 1% co
 | Starting feature work in isolation | `mobiai-mobile-worktrees` |
 | Implementation done, need to integrate | `mobiai-mobile-finishing-branch` |
 | Creating a new MobiAI skill | `mobiai-writing-skills` |
+| User asks about code impact, call graph, callers/callees, "where is X used", semantic exploration of the codebase | `mobiai-graph` |
 | User asks about project decisions, bugfixes, workarounds, or "what did we decide last time" | `mobiai-brain` |
 
 If the request doesn't match any row, ask the user to clarify before touching code. Do not improvise a workflow.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,5 +95,30 @@ if [ -n "${RC}" ] && ! echo "${PATH}" | grep -q "${INSTALL_DIR}"; then
     echo "  source ${RC}"
 fi
 
+# Welcome banner — printed last so the user's eye lands on the
+# wordmark + next step together. Respect NO_COLOR per the spec
+# (https://no-color.org/) and skip ANSI when stdout isn't a tty.
 echo ""
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    BANNER_COLOR="\033[1;36m"   # bold cyan
+    TAGLINE_COLOR="\033[2;37m"  # dim white
+    RESET="\033[0m"
+else
+    BANNER_COLOR=""
+    TAGLINE_COLOR=""
+    RESET=""
+fi
+
+printf '%s' "${BANNER_COLOR}"
+cat <<'BANNER'
+███╗   ███╗  ██████╗  ██████╗  ██╗       ██████╗  ██╗
+████╗ ████║ ██╔═══██╗ ██╔══██╗ ██║      ██╔═══██╗ ██║
+██╔████╔██║ ██║   ██║ ██████╔╝ ██║      ███████║ ██║
+██║╚██╔╝██║ ██║   ██║ ██╔══██╗ ██║      ██╔══██║ ██║
+██║ ╚═╝ ██║ ╚██████╔╝ ██████╔╝ ██║      ██║  ██║ ██║
+╚═╝     ╚═╝  ╚═════╝  ╚═════╝  ╚═╝      ╚═╝  ╚═╝ ╚═╝
+BANNER
+printf '%s\n\n' "${RESET}"
+printf '%s            AI FOR MOBILE DEVELOPERS%s\n\n' "${TAGLINE_COLOR}" "${RESET}"
+
 echo "Próximo paso: mobiai --version"


### PR DESCRIPTION
## Summary

Estrena **MobiAI Graph** como tercera pieza del ecosistema, complementando Skills (cómo trabajar) y Brain (qué se decidió). Graph entiende la estructura **actual** del código mobile: símbolos, referencias, impacto.

- **Capacidad nueva**: exploración semántica del código vía `mobiai graph search/callers/context`.
- **Stack**: motor propio en Go, regex line-by-line, persistencia JSON en `.mobiai/graph/index.json`. **Cero dependencias nuevas**, cero CGo, cero SQLite/tree-sitter en V1.
- **Lenguajes V1**: Kotlin + Swift.
- **Inspiración**: [CodeGraph](https://github.com/colbymchenry/codegraph) (TypeScript + tree-sitter + SQLite) en proyectos web. MobiAI Graph lleva la idea al terreno mobile con stack Go nativo.

## Por qué cada pieza

- **Motor propio (no wrapper de CodeGraph)**: para no atarse a un binario externo y poder evolucionar la semántica hacia patrones mobile específicos (Compose→ViewModel→UseCase, KMP expect/actual, etc.) en V3 sin pedir permiso.
- **Regex en vez de tree-sitter en V1**: con solo Kotlin+Swift, el costo de tree-sitter (CGo, distribución de grammars, cross-compile complicado del install.sh) no se justifica. Cuando V2 sume Dart/JS-TS/Java, ahí se reevalúa.
- **JSON en vez de SQLite**: el índice de un proyecto mobile típico cabe en <5MB. FTS5 no aporta a esa escala. Y SQLite/CGo rompe la propiedad "binario Go puro".
- **Sin watcher en V1**: `graph init` regenera entero. Watcher es V2 cuando el indexado sea más caro.

## Platform

- **Plataforma**: cross-platform (CLI Go).
- **Targets indexados**: Kotlin (Android, KMP `shared`/`androidMain`) y Swift (iOS, KMP `iosMain`). Dart, JS/TS, Java → V2 (roadmap).
- **Permisos nuevos**: ninguno.

## Changes

- `cli/internal/graph/` — nuevo módulo Go con:
  - `model.go` — tipos `Index / FileIndex / Symbol` + `IndexVersion = 1`.
  - `storage.go` — `Write` atómico (.tmp + fsync + rename), `Read` con check de versión.
  - `kotlin.go` + `swift.go` — scanners regex con state machine que strips comentarios y string literals (preserva line numbers).
  - `indexer.go` — `Build()` con `filepath.WalkDir`, exclusiones `.git/build/Pods/...`, output determinístico.
  - `query.go` — `Search` (exact > prefix > substring), `Callers` (whole-word, excluye defs), `Context` (token overlap heurístico).
  - `testdata/kotlin/` + `testdata/swift/` — fixtures.
- `cli/internal/cmd/graph.go` — subcomando `mobiai graph` con 5 acciones: `init / status / search / callers / context`. Mismo patrón que `brain.go`. Mensajes en español.
- `cli/cmd/mobiai/main.go` — 1 línea: `root.AddCommand(cmd.NewGraphCmd())`.
- `plugins/core/skills/mobiai-graph/SKILL.md` — skill nueva que enseña a los agentes cuándo y cómo usar el grafo, combinación con Brain, limitaciones V1.
- `plugins/core/skills/using-mobiai/SKILL.md` — 1 fila en la Quick Decision Guide.
- `docs/graph.md` — visión, arquitectura V1, roadmap V2/V3/V4 explícitamente marcado como no implementado.

## Test Plan

- [x] 60+ tests unitarios + integración pasan (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] Smoke test E2E sobre proyecto fake Android+iOS: init / status / search / callers / context devuelven resultados correctos cross-platform.
- [x] Cero dependencias Go nuevas (`go.mod` intacto)

## Regression Risk

- Solo adiciones nuevas, sin tocar Brain ni el resto de la CLI.
- El único archivo existente modificado es `cli/cmd/mobiai/main.go` (1 línea registrando el subcomando).
- `using-mobiai/SKILL.md` recibe 1 fila adicional, ningún reorder.
- **Riesgo**: bajo. Los scanners regex pueden tener falsos positivos en sintaxis Kotlin/Swift muy poco común — documentado como limitación V1.

## Notas

Rama creada desde `feat/branding-banner`. Si esa rama no mergea antes, el PR incluirá su commit del banner (`661affb`). Avisame si querés que rebasee a `main` para eliminarlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)