### PR TITLE
fix(installer): emitir bytes ESC reales en el banner ANSI

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,9 +100,12 @@ fi
 # (https://no-color.org/) and skip ANSI when stdout isn't a tty.
 echo ""
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
-    BANNER_COLOR="\033[1;36m"   # bold cyan
-    TAGLINE_COLOR="\033[2;37m"  # dim white
-    RESET="\033[0m"
+    # POSIX sh no interpreta \033 dentro de comillas dobles; hay que materializar
+    # el byte ESC con printf para que las secuencias ANSI viajen como tales y no
+    # como cuatro caracteres literales.
+    BANNER_COLOR="$(printf '\033[1;36m')"   # bold cyan
+    TAGLINE_COLOR="$(printf '\033[2;37m')"  # dim white
+    RESET="$(printf '\033[0m')"
 else
     BANNER_COLOR=""
     TAGLINE_COLOR=""


### PR DESCRIPTION
## Summary
- **Issue**: usuarios que instalan vía \`curl -fsSL https://mobiai.dev/install.sh | sh\` ven el banner como texto crudo en lugar de coloreado:
  \`\`\`
  \033[1;36m███╗   ███╗  ██████╗ …
  …
  \033[0m
  \`\`\`
- **Root cause**: en POSIX \`sh\`, la asignación \`BANNER_COLOR="\033[1;36m"\` guarda los **4 caracteres literales** \`\\\`, \`0\`, \`3\`, \`3\` — no el byte ESC (0x1B). Al imprimir con \`printf '%s' "\${BANNER_COLOR}"\`, la terminal recibe la cadena textual y no la interpreta como secuencia ANSI.
- **Breaking commit**: always-existed — el bug está desde el primer día del instalador (no es regresión). Solo se manifestó ahora porque ya hay usuarios reales instalando vía \`mobiai.dev/install.sh\`.
- **Fix**: materializar el byte ESC con \`\$(printf '\033[1;36m')\` al asignar, de modo que la variable contenga la secuencia real desde el inicio.

## Why each change
- **\`BANNER_COLOR\`, \`TAGLINE_COLOR\`, \`RESET\` ahora se asignan vía \`\$(printf '…')\`**: \`printf\` *sí* interpreta \`\\\\033\` como byte ESC, mientras que la asignación directa entre comillas dobles no. Tras este cambio la variable contiene el carácter ESC real y \`printf '%s' "\${BANNER_COLOR}"\` funciona como se espera.
- **Alternativas descartadas**:
  - \`printf '%b'\` en vez de \`%s\`: funciona pero requiere cambiar todos los call-sites y es frágil si alguien añade un nuevo \`printf\`/\`echo\` con la variable.
  - \`BANNER_COLOR=\$'\\\\033[1;36m'\`: bashismo (ANSI-C quoting), rompe en \`dash\` y otros POSIX strict shells.
  - El enfoque \`\$(printf …)\` es el más portable: funciona idéntico en \`sh\`, \`bash\`, \`zsh\` y \`dash\`.
- **Comentario añadido**: deja explicado el porqué para evitar que un futuro refactor revierta el cambio "porque parece redundante".

## Platform
- **Affected platform**: instalador macOS/Linux (\`scripts/install.sh\`). Las versiones Windows (\`install.cmd\`, \`install.ps1\`) no se ven afectadas — usan otros mecanismos de color.
- **Min SDK / deployment target affected**: n/a
- **New permissions or entitlements**: none

## Changes
- \`scripts/install.sh\` — líneas 102-110: las tres asignaciones de color dentro del bloque \`if [ -t 1 ] && [ -z "\${NO_COLOR:-}" ]\` pasan de string literal con backslashes a \`\$(printf '…')\`. Sin cambios fuera del bloque.

## Test Plan
- [x] Reproducido el bug: \`/bin/sh -c 'X="\\\\033[1;36m"; printf "%s" "\$X"' | od -c\` muestra \`\\\\ 0 3 3 [ 1 ; 3 6 m\` (4 chars literales).
- [x] Verificado el fix: \`/bin/sh -c 'X="\$(printf "\\\\033[1;36m")"; printf "%s" "\$X"' | od -c\` muestra \`033 [ 1 ; 3 6 m\` (byte ESC real, 0x1B).
- [ ] Probar end-to-end: \`curl -fsSL https://mobiai.dev/install.sh | sh\` tras el merge (Vercel proxea a \`main\`, así que el cambio se propaga en cuanto el rewrite refresca caché).
- [ ] Confirmar que con \`NO_COLOR=1 sh install.sh\` el banner sale sin colores (rama \`else\` intacta).

## Regression Risk
- [ ] Touches Activity/Fragment lifecycle or ViewController lifecycle
- [ ] Touches threading / coroutines / Dispatchers / GCD
- [ ] Touches navigation graph or deep links
- [ ] Modifies ProGuard / R8 rules or iOS build settings
- [ ] Changes dependency versions
- **Risk notes**: cambio aislado al instalador. No toca el binario \`mobiai\` ni el catálogo de skills. Si por algún motivo el fix fallara, el peor caso sería volver a ver \`\\\\033[1;36m\` crudo (estado previo) — ningún error de instalación.