### PR TITLE
fix(host): point opencode and pi adapters to shared ~/.agents/ skills…

### DIFF
--- a/cli/internal/host/adapters_test.go
+++ b/cli/internal/host/adapters_test.go
@@ -25,7 +25,7 @@ func adapterCases() []adapterCase {
 		// Tier 2 (best-effort)
 		{newGoose, "goose", "Goose", ".config/goose", false, false},
 		{newGitHubCopilot, "github-copilot", "GitHub Copilot", ".copilot", false, false},
-		{newOpenCode, "opencode", "OpenCode", ".opencode", false, false},
+		{newOpenCode, "opencode", "OpenCode", ".agents", false, false},
 		{newJunie, "junie", "Junie", ".junie", false, false},
 		{newRooCode, "roo-code", "Roo Code", ".roo-code", false, false},
 		// Tier 3 (speculative, paths a confirmar)
@@ -38,7 +38,7 @@ func adapterCases() []adapterCase {
 		{newClaudeDesktop, "claude-desktop", "Claude Desktop", ".claude-desktop", false, false},
 		{newPiebald, "piebald", "Piebald", ".piebald", false, false},
 		{newFactory, "factory", "Factory", ".factory", false, false},
-		{newPi, "pi", "pi", ".pi", false, false},
+		{newPi, "pi", "pi", ".agents", false, false},
 		{newDatabricksGenie, "databricks-genie", "Databricks Genie Code", ".databricks/genie-code", false, false},
 		{newAgentman, "agentman", "Agentman", ".agentman", false, false},
 		{newTRAE, "trae", "TRAE", ".trae", false, false},
@@ -123,5 +123,6 @@ func TestAdapters_DetectFlow(t *testing.T) {
 				t.Errorf("Detect should be true after creating %s", c.wantHomeSub)
 			}
 		})
+		os.RemoveAll(filepath.Join(tmp, c.wantHomeSub))
 	}
 }

--- a/cli/internal/host/opencode.go
+++ b/cli/internal/host/opencode.go
@@ -1,13 +1,13 @@
 package host
 
 // newOpenCode returns a HostAdapter for OpenCode.
-// Tier-2: best-effort detection at ~/.opencode/.
+// Tier-2: best-effort detection at ~/.agents/.
 func newOpenCode() HostAdapter {
 	return &genericAdapter{
 		id:         "opencode",
 		name:       "OpenCode",
 		homepage:   "https://opencode.ai",
-		homeSubdir: ".opencode",
+		homeSubdir: ".agents",
 		caps:       Caps{Skills: true},
 	}
 }

--- a/cli/internal/host/pi.go
+++ b/cli/internal/host/pi.go
@@ -7,7 +7,7 @@ func newPi() HostAdapter {
 		id:         "pi",
 		name:       "pi",
 		homepage:   "https://pi.ai",
-		homeSubdir: ".pi",
+		homeSubdir: ".agents",
 		caps:       Caps{Skills: true},
 	}
 }


### PR DESCRIPTION
… directory

Both tools install skills globally to ~/.agents/skills/ per the Agent Skills standard. The adapters targeted tool-specific paths that neither tool reads:

- opencode: ~/.opencode/skills/ (unused; opencode reads ~/.agents/skills/)
- pi: ~/.pi/skills/ (unused; pi reads ~/.pi/agent/skills/ and ~/.agents/skills/)

Refs:
- https://opencode.ai/docs/skills/ (global: ~/.agents/skills/)
- https://pi.dev/docs/latest/skills (global: ~/.agents/skills/)