### PR TITLE
feat(i18n): `mobiai lang es|en` para traducir el CLI

### DIFF
--- a/cli/cmd/mobiai/main.go
+++ b/cli/cmd/mobiai/main.go
@@ -8,44 +8,48 @@ import (
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/branding"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/cmd"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 )
 
 // version is set at build time via -ldflags "-X main.version=..."
 var version = "dev"
 
-// usageTemplate mirrors cobra's default but with Spanish labels and
-// ANSI styling. The `head`, `styleCmd` and `dim` funcs come from the
-// `branding` package and short-circuit to plain text when --no-color,
-// NO_COLOR, or a non-TTY destination is detected.
+// usageTemplate mirrors cobra's default but with localized labels and ANSI
+// styling. The `head`, `styleCmd` and `dim` funcs come from the `branding`
+// package and short-circuit to plain text when --no-color, NO_COLOR, or a
+// non-TTY destination is detected. It is a function (not a const) so the
+// headings resolve through i18n.T at build time, after the language is set.
 //
-// We apply the style funcs AFTER rpad so cobra's column width calc
-// (which counts bytes) doesn't see the escape sequences. Wrapping the
-// padded string is fine visually — the escape brackets the whole token
-// including its trailing spaces.
-const usageTemplate = `{{head "Usage:"}}{{if .Runnable}}
+// We apply the style funcs AFTER rpad so cobra's column width calc (which
+// counts bytes) doesn't see the escape sequences. "Flags:" is left untranslated
+// (identical in both languages).
+func usageTemplate() string {
+	return `{{head "` + i18n.T("Usage:") + `"}}{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+  {{.CommandPath}} ` + i18n.T("[command]") + `{{end}}{{if gt (len .Aliases) 0}}
 
-{{head "Aliases:"}}
+{{head "` + i18n.T("Aliases:") + `"}}
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
-{{head "Examples:"}}
+{{head "` + i18n.T("Examples:") + `"}}
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
-{{head "Available commands:"}}{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+{{head "` + i18n.T("Available commands:") + `"}}{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding | styleCmd}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 {{head "Flags:"}}
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
-{{head "Global flags:"}}
+{{head "` + i18n.T("Global flags:") + `"}}
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
-{{head "Additional topics:"}}{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+{{head "` + i18n.T("Additional topics:") + `"}}{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding | styleCmd}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
-Use "{{styleCmd (printf "%s [command] --help" .CommandPath)}}" for more information about a command.{{end}}
+` + i18n.T("Use ") + `"{{styleCmd (printf "%s ` + i18n.T("[command]") + ` --help" .CommandPath)}}" ` + i18n.T("for more information about a command.") + `{{end}}
 `
+}
 
 func newRootCmd(v string) *cobra.Command {
 	cmd.SetVersion(v)
@@ -59,8 +63,8 @@ func newRootCmd(v string) *cobra.Command {
 
 	root := &cobra.Command{
 		Use:     "mobiai",
-		Short:   "MobiAI CLI — manage the MobiAI ecosystem for AI-assisted mobile development",
-		Long:    "MobiAI CLI is the unified tool of the MobiAI ecosystem: skills, agents, MCPs, and orchestration across clients for AI-assisted mobile development. Today it manages skills compatible with the agentskills.io standard on any supported client; agents and MCP servers are coming soon.",
+		Short:   i18n.T("MobiAI CLI — manage the MobiAI ecosystem for AI-assisted mobile development"),
+		Long:    i18n.T("MobiAI CLI is the unified tool of the MobiAI ecosystem: skills, agents, MCPs, and orchestration across clients for AI-assisted mobile development. Today it manages skills compatible with the agentskills.io standard on any supported client; agents and MCP servers are coming soon."),
 		Version: v,
 		// Sin subcomando: banner + help. El selector interactivo vive en
 		// `mobiai skills init` (consistente con `mobiai brain init`).
@@ -73,17 +77,17 @@ func newRootCmd(v string) *cobra.Command {
 		},
 	}
 	root.SetVersionTemplate("mobiai {{.Version}}\n")
-	root.SetUsageTemplate(usageTemplate)
+	root.SetUsageTemplate(usageTemplate())
 	cmd.AddPersistentFlags(root)
 
 	root.SetHelpCommand(&cobra.Command{
 		Use:   "help [command]",
-		Short: "Help about any command",
-		Long:  "Help about any mobiai command.",
+		Short: i18n.T("Help about any command"),
+		Long:  i18n.T("Help about any mobiai command."),
 		Run: func(c *cobra.Command, args []string) {
 			target, _, err := c.Root().Find(args)
 			if target == nil || err != nil {
-				c.Printf("Unknown command %q\n", args)
+				c.Printf(i18n.T("Unknown command %q\n"), args)
 				_ = c.Root().Usage()
 				return
 			}
@@ -96,14 +100,10 @@ func newRootCmd(v string) *cobra.Command {
 	// become useful for real users.
 	root.CompletionOptions.DisableDefaultCmd = true
 
-	// Translate the auto-added help and version flag descriptions.
-	root.InitDefaultHelpFlag()
-	if f := root.Flags().Lookup("help"); f != nil {
-		f.Usage = "help for mobiai"
-	}
+	// Translate the auto-added version flag description (root-only flag).
 	root.InitDefaultVersionFlag()
 	if f := root.Flags().Lookup("version"); f != nil {
-		f.Usage = "mobiai version"
+		f.Usage = i18n.T("mobiai version")
 	}
 
 	root.AddCommand(cmd.NewCatalogCmd())
@@ -114,10 +114,41 @@ func newRootCmd(v string) *cobra.Command {
 	root.AddCommand(cmd.NewUpdateCmd())
 	root.AddCommand(cmd.NewBrainCmd())
 	root.AddCommand(cmd.NewGraphCmd())
+	root.AddCommand(cmd.NewLangCmd())
+
+	// Localize the auto-generated `--help` flag usage for every command in the
+	// tree. Cobra defaults it to "help for <cmd>", which would otherwise leak
+	// English into the Flags section of each subcommand's help in es mode.
+	localizeHelpFlags(root)
 	return root
 }
 
+// localizeHelpFlags walks the command tree and rewrites each command's
+// auto-generated `--help` flag usage to the active language.
+func localizeHelpFlags(c *cobra.Command) {
+	c.InitDefaultHelpFlag()
+	if f := c.Flags().Lookup("help"); f != nil {
+		f.Usage = fmt.Sprintf(i18n.T("help for %s"), c.Name())
+	}
+	for _, sub := range c.Commands() {
+		localizeHelpFlags(sub)
+	}
+}
+
 func main() {
+	// Resolve the CLI language BEFORE building the command tree, so cobra
+	// Short/Long/flag-usage strings render in the active language. Precedence
+	// (MOBIAI_LANG > persisted preference > EN) lives in i18n.Init; here we
+	// just feed it the persisted value. Config errors are non-fatal — we fall
+	// back to English rather than block startup.
+	var persisted string
+	if paths, err := state.NewPaths(); err == nil {
+		if cfg, err := state.LoadConfig(paths); err == nil {
+			persisted = cfg.Lang
+		}
+	}
+	i18n.Init(persisted)
+
 	if err := newRootCmd(version).Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cli/internal/cmd/brain.go
+++ b/cli/internal/cmd/brain.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/brain"
 	brainmcp "github.com/ArisGuimera/MobiAI-Core/cli/internal/brain/mcp"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/branding"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 )
 
 // NewBrainCmd builds `mobiai brain <init|scan|context>`.
@@ -24,10 +25,8 @@ import (
 func NewBrainCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "brain",
-		Short: "Per-project memory for mobile agents",
-		Long: "MobiAI Brain stores living per-project context: detected stack, " +
-			"decisions, bugfixes, testing patterns and integrations. " +
-			"Lives at <repo>/.mobiai/brain/ — separate from the CLI's global state.",
+		Short: i18n.T("Per-project memory for mobile agents"),
+		Long: i18n.T("MobiAI Brain stores living per-project context: detected stack, decisions, bugfixes, testing patterns and integrations. Lives at <repo>/.mobiai/brain/ — separate from the CLI's global state."),
 	}
 	root.AddCommand(
 		newBrainInitCmd(),
@@ -48,7 +47,7 @@ func NewBrainCmd() *cobra.Command {
 // When omitted, the command resolves the project root by walking up
 // from the current working directory (see brain.FindProjectRoot).
 func brainCommonFlags(c *cobra.Command) {
-	c.Flags().String("root", "", "project path (default: detected from cwd)")
+	c.Flags().String("root", "", i18n.T("project path (default: detected from cwd)"))
 }
 
 // resolveBrainRoot returns the project root for a brain command. It
@@ -75,7 +74,7 @@ func resolveBrainRoot(c *cobra.Command) (brain.RootInfo, error) {
 func newBrainInitCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "init",
-		Short: "Initialize .mobiai/brain in the current project",
+		Short: i18n.T("Initialize .mobiai/brain in the current project"),
 		RunE:  runBrainInit,
 	}
 	brainCommonFlags(c)
@@ -97,9 +96,9 @@ func runBrainInit(c *cobra.Command, _ []string) error {
 		return err
 	}
 	if info.Warning != "" {
-		fmt.Fprintf(out, "⚠ %s (using %s)\n", info.Warning, info.Path)
+		fmt.Fprintf(out, i18n.T("⚠ %s (using %s)\n"), info.Warning, info.Path)
 	} else {
-		fmt.Fprintf(out, "Detected project: %s\n", info.Path)
+		fmt.Fprintf(out, i18n.T("Detected project: %s\n"), info.Path)
 	}
 
 	paths := brain.NewBrainPaths(info.Path)
@@ -124,24 +123,24 @@ func runBrainInit(c *cobra.Command, _ []string) error {
 	}
 
 	if createdConfig {
-		fmt.Fprintf(out, "✓ created %s\n", relTo(info.Path, paths.ConfigFile))
+		fmt.Fprintf(out, i18n.T("✓ created %s\n"), relTo(info.Path, paths.ConfigFile))
 	} else {
-		fmt.Fprintf(out, "= %s already exists (not overwritten)\n", relTo(info.Path, paths.ConfigFile))
+		fmt.Fprintf(out, i18n.T("= %s already exists (not overwritten)\n"), relTo(info.Path, paths.ConfigFile))
 	}
 	if len(createdMemories) > 0 {
-		fmt.Fprintf(out, "✓ memories initialized: %s\n", strings.Join(createdMemories, ", "))
+		fmt.Fprintf(out, i18n.T("✓ memories initialized: %s\n"), strings.Join(createdMemories, ", "))
 	} else {
-		fmt.Fprintln(out, "= memories already exist (not overwritten)")
+		fmt.Fprintln(out, i18n.T("= memories already exist (not overwritten)"))
 	}
 	fmt.Fprintln(out, "")
-	fmt.Fprintln(out, "Next step: `mobiai brain scan` to detect the stack.")
+	fmt.Fprintln(out, i18n.T("Next step: `mobiai brain scan` to detect the stack."))
 	return nil
 }
 
 func newBrainScanCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "scan",
-		Short: "Scan the project and detect the mobile stack",
+		Short: i18n.T("Scan the project and detect the mobile stack"),
 		RunE:  runBrainScan,
 	}
 	brainCommonFlags(c)
@@ -159,7 +158,7 @@ func runBrainScan(c *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not find .mobiai/brain/config.json in %s. Run `mobiai brain init` first", info.Path)
 	}
 
-	fmt.Fprintf(out, "Scanning %s ...\n", info.Path)
+	fmt.Fprintf(out, i18n.T("Scanning %s ...\n"), info.Path)
 	scan, err := brain.ScanProject(info.Path)
 	if err != nil {
 		return err
@@ -186,7 +185,7 @@ func runBrainScan(c *cobra.Command, _ []string) error {
 	}
 
 	printScanSummary(out, scan)
-	fmt.Fprintf(out, "✓ scan saved to %s\n", relTo(info.Path, paths.ScanFile))
+	fmt.Fprintf(out, i18n.T("✓ scan saved to %s\n"), relTo(info.Path, paths.ScanFile))
 	return nil
 }
 
@@ -194,10 +193,10 @@ func printScanSummary(out io.Writer, s *brain.Scan) {
 	w := func(format string, args ...interface{}) {
 		fmt.Fprintf(out, format, args...)
 	}
-	w("\nSummary:\n")
-	w("  Type:        %s\n", s.ProjectType)
+	fmt.Fprint(out, i18n.T("\nSummary:\n"))
+	w(i18n.T("  Type:        %s\n"), s.ProjectType)
 	if len(s.Platforms) > 0 {
-		w("  Platforms:   %s\n", strings.Join(s.Platforms, ", "))
+		w(i18n.T("  Platforms:   %s\n"), strings.Join(s.Platforms, ", "))
 	}
 	for _, row := range []struct {
 		label string
@@ -217,7 +216,7 @@ func printScanSummary(out io.Writer, s *brain.Scan) {
 		w("  %-12s %s\n", row.label+":", strings.Join(row.items, ", "))
 	}
 	if len(s.Warnings) > 0 {
-		w("  Warnings:    %d\n", len(s.Warnings))
+		w(i18n.T("  Warnings:    %d\n"), len(s.Warnings))
 	}
 	w("\n")
 }
@@ -225,21 +224,19 @@ func printScanSummary(out io.Writer, s *brain.Scan) {
 func newBrainContextCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "context",
-		Short: "Print the Brain's Markdown context (config + scan + memories)",
-		Long: "Prints the Brain context as Markdown. Without flags, dumps everything. " +
-			"With --section, --platform, --status or --area, filters memory entries so " +
-			"only what's relevant appears (useful as the brain grows).",
+		Short: i18n.T("Print the Brain's Markdown context (config + scan + memories)"),
+		Long: i18n.T("Prints the Brain context as Markdown. Without flags, dumps everything. With --section, --platform, --status or --area, filters memory entries so only what's relevant appears (useful as the brain grows)."),
 		RunE: runBrainContext,
 	}
 	brainCommonFlags(c)
 	c.Flags().StringSlice("section", nil,
-		"limit sections to render (stack,rules,decisions,bugfixes,testing,integrations,releases,warnings). Repeatable or comma-separated.")
+		i18n.T("limit sections to render (stack,rules,decisions,bugfixes,testing,integrations,releases,warnings). Repeatable or comma-separated."))
 	c.Flags().String("platform", "",
-		"filter entries by platform (android|ios|shared|kmp|flutter|react-native)")
+		i18n.T("filter entries by platform (android|ios|shared|kmp|flutter|react-native)"))
 	c.Flags().String("status", "",
-		"filter entries by status (active|temporary|deprecated)")
+		i18n.T("filter entries by status (active|temporary|deprecated)"))
 	c.Flags().String("area", "",
-		"filter entries whose area contains this string (substring)")
+		i18n.T("filter entries whose area contains this string (substring)"))
 	return c
 }
 
@@ -279,17 +276,15 @@ func runBrainContext(c *cobra.Command, _ []string) error {
 func newBrainSearchCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "search <query>",
-		Short: "Free-text search across Brain memories",
-		Long: "Performs a case-insensitive match against the title and body of each " +
-			"memory entry. The --platform/--status/--area flags filter results with " +
-			"AND semantics.",
+		Short: i18n.T("Free-text search across Brain memories"),
+		Long: i18n.T("Performs a case-insensitive match against the title and body of each memory entry. The --platform/--status/--area flags filter results with AND semantics."),
 		Args: cobra.MinimumNArgs(1),
 		RunE: runBrainSearch,
 	}
 	brainCommonFlags(c)
-	c.Flags().String("platform", "", "limit to entries with this platform")
-	c.Flags().String("status", "", "limit to entries with this status")
-	c.Flags().String("area", "", "limit to entries whose area contains this string")
+	c.Flags().String("platform", "", i18n.T("limit to entries with this platform"))
+	c.Flags().String("status", "", i18n.T("limit to entries with this status"))
+	c.Flags().String("area", "", i18n.T("limit to entries whose area contains this string"))
 	return c
 }
 
@@ -316,10 +311,10 @@ func runBrainSearch(c *cobra.Command, args []string) error {
 		return err
 	}
 	if len(hits) == 0 {
-		fmt.Fprintf(out, "No results for %q.\n", query)
+		fmt.Fprintf(out, i18n.T("No results for %q.\n"), query)
 		return nil
 	}
-	fmt.Fprintf(out, "%d result(s) for %q:\n\n", len(hits), query)
+	fmt.Fprintf(out, i18n.T("%d result(s) for %q:\n\n"), len(hits), query)
 	for _, h := range hits {
 		// Format: `[section] title (status, platform) — snippet`
 		var meta []string
@@ -361,20 +356,15 @@ func truncate(s string, maxLen int) string {
 func newBrainReviewCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "review",
-		Short: "List temporary entries whose review_after has passed",
-		Long: "Walks the memories and shows entries with status: temporary " +
-			"whose review_after <= today. Designed to keep temporary workarounds " +
-			"from drifting into permanence by inertia. By default exits with " +
-			"status 1 if there are overdue entries (useful as a CI / pre-commit " +
-			"gate); pass --no-fail to only report. With --include-no-date it " +
-			"also lists temporary entries without a review_after assigned.",
+		Short: i18n.T("List temporary entries whose review_after has passed"),
+		Long: i18n.T("Walks the memories and shows entries with status: temporary whose review_after <= today. Designed to keep temporary workarounds from drifting into permanence by inertia. By default exits with status 1 if there are overdue entries (useful as a CI / pre-commit gate); pass --no-fail to only report. With --include-no-date it also lists temporary entries without a review_after assigned."),
 		RunE: runBrainReview,
 	}
 	brainCommonFlags(c)
 	c.Flags().Bool("include-no-date", false,
-		"also list temporary entries without review_after (printed under a separate heading)")
+		i18n.T("also list temporary entries without review_after (printed under a separate heading)"))
 	c.Flags().Bool("no-fail", false,
-		"always exit 0, even if there are overdue entries (informational mode)")
+		i18n.T("always exit 0, even if there are overdue entries (informational mode)"))
 	return c
 }
 
@@ -402,19 +392,19 @@ func runBrainReview(c *cobra.Command, _ []string) error {
 	overdue, noDate := splitReviewItems(items)
 
 	if len(overdue) == 0 && len(noDate) == 0 {
-		fmt.Fprintln(out, "✓ No overdue temporary entries.")
+		fmt.Fprintln(out, i18n.T("✓ No overdue temporary entries."))
 		return nil
 	}
 
 	if len(overdue) > 0 {
-		fmt.Fprintf(out, "⚠ %d overdue temporary entry(ies):\n\n", len(overdue))
+		fmt.Fprintf(out, i18n.T("⚠ %d overdue temporary entry(ies):\n\n"), len(overdue))
 		printOverdueItems(out, overdue)
 	} else {
-		fmt.Fprintln(out, "✓ No overdue entries.")
+		fmt.Fprintln(out, i18n.T("✓ No overdue entries."))
 	}
 
 	if len(noDate) > 0 {
-		fmt.Fprintf(out, "\n%d temporary entry(ies) without review_after:\n\n", len(noDate))
+		fmt.Fprintf(out, i18n.T("\n%d temporary entry(ies) without review_after:\n\n"), len(noDate))
 		printNoDateItems(out, noDate)
 	}
 
@@ -449,7 +439,7 @@ func printOverdueItems(out io.Writer, items []brain.ReviewItem) {
 			currentSection = it.Section
 		}
 		fmt.Fprintf(out, "  ⚠ %s\n", it.Entry.Title)
-		fmt.Fprintf(out, "    review_after: %s (overdue by %s)\n",
+		fmt.Fprintf(out, i18n.T("    review_after: %s (overdue by %s)\n"),
 			it.ReviewAfter, daysOverdueLabel(it.DaysOverdue))
 		if p := it.Entry.Get("platform"); p != "" {
 			fmt.Fprintf(out, "    platform: %s\n", p)
@@ -485,19 +475,15 @@ func printNoDateItems(out io.Writer, items []brain.ReviewItem) {
 func newBrainPromoteCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "promote <id>",
-		Short: "Change the status of an existing entry",
-		Long: "Updates the status: of the entry with the given id (active|temporary|" +
-			"deprecated). Designed as the wrap-up flow after `brain review`: once you no " +
-			"longer need a temporary entry, promote it to active (it became permanent) " +
-			"or deprecated (no longer applies). Optionally also updates review_after in " +
-			"the same call, or removes it with --clear-review-after.",
+		Short: i18n.T("Change the status of an existing entry"),
+		Long: i18n.T("Updates the status: of the entry with the given id (active|temporary|deprecated). Designed as the wrap-up flow after `brain review`: once you no longer need a temporary entry, promote it to active (it became permanent) or deprecated (no longer applies). Optionally also updates review_after in the same call, or removes it with --clear-review-after."),
 		Args: cobra.ExactArgs(1),
 		RunE: runBrainPromote,
 	}
 	brainCommonFlags(c)
-	c.Flags().String("status", "", "new status: active|temporary|deprecated (required)")
-	c.Flags().String("review-after", "", "also update review_after to this YYYY-MM-DD date (optional)")
-	c.Flags().Bool("clear-review-after", false, "remove review_after (incompatible with --review-after)")
+	c.Flags().String("status", "", i18n.T("new status: active|temporary|deprecated (required)"))
+	c.Flags().String("review-after", "", i18n.T("also update review_after to this YYYY-MM-DD date (optional)"))
+	c.Flags().Bool("clear-review-after", false, i18n.T("remove review_after (incompatible with --review-after)"))
 	_ = c.MarkFlagRequired("status")
 	return c
 }
@@ -517,15 +503,13 @@ func runBrainPromote(c *cobra.Command, args []string) error {
 func newBrainBumpCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "bump <id>",
-		Short: "Extend the review_after of an existing entry",
-		Long: "Updates review_after of the entry with the given id, without touching status. " +
-			"Useful after `brain review` when a temporary entry is still valid and you " +
-			"want to extend its review deadline. For status changes use `promote`.",
+		Short: i18n.T("Extend the review_after of an existing entry"),
+		Long: i18n.T("Updates review_after of the entry with the given id, without touching status. Useful after `brain review` when a temporary entry is still valid and you want to extend its review deadline. For status changes use `promote`."),
 		Args: cobra.ExactArgs(1),
 		RunE: runBrainBump,
 	}
 	brainCommonFlags(c)
-	c.Flags().String("review-after", "", "new YYYY-MM-DD date for review_after (required)")
+	c.Flags().String("review-after", "", i18n.T("new YYYY-MM-DD date for review_after (required)"))
 	_ = c.MarkFlagRequired("review-after")
 	return c
 }
@@ -555,7 +539,7 @@ func doBrainUpdate(c *cobra.Command, id string, opts brain.UpdateOptions) error 
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "✓ %s updated (%s)\n", res.Title, res.File)
+	fmt.Fprintf(out, i18n.T("✓ %s updated (%s)\n"), res.Title, res.File)
 	if res.PrevStatus != res.NewStatus {
 		fmt.Fprintf(out, "  status: %s → %s\n", res.PrevStatus, res.NewStatus)
 	}
@@ -578,29 +562,27 @@ func doBrainUpdate(c *cobra.Command, id string, opts brain.UpdateOptions) error 
 func daysOverdueLabel(days int) string {
 	switch {
 	case days == 0:
-		return "today"
+		return i18n.T("today")
 	case days == 1:
-		return "1 day"
+		return i18n.T("1 day")
 	default:
-		return fmt.Sprintf("%d days", days)
+		return fmt.Sprintf(i18n.T("%d days"), days)
 	}
 }
 
 func newBrainSaveCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "save",
-		Short: "Save an entry into the Brain's memories",
-		Long: "Appends a structured entry to the matching memory file. " +
-			"Requires the Brain to be initialized in the project " +
-			"(run `mobiai brain init` first).",
+		Short: i18n.T("Save an entry into the Brain's memories"),
+		Long: i18n.T("Appends a structured entry to the matching memory file. Requires the Brain to be initialized in the project (run `mobiai brain init` first)."),
 	}
 	root.AddCommand(
 		newBrainSaveSubCmd(brain.SaveTypeDecision, "decision",
-			"Save an architecture decision"),
+			i18n.T("Save an architecture decision")),
 		newBrainSaveSubCmd(brain.SaveTypeBugfix, "bugfix",
-			"Save a bugfix or workaround"),
+			i18n.T("Save a bugfix or workaround")),
 		newBrainSaveSubCmd(brain.SaveTypeTesting, "testing",
-			"Save a reusable testing pattern"),
+			i18n.T("Save a reusable testing pattern")),
 	)
 	return root
 }
@@ -614,13 +596,13 @@ func newBrainSaveSubCmd(saveType brain.SaveType, use, short string) *cobra.Comma
 		},
 	}
 	brainCommonFlags(c)
-	c.Flags().String("title", "", "short entry title (required)")
-	c.Flags().String("platform", "", "android|ios|shared|kmp|flutter|react-native (optional)")
-	c.Flags().String("area", "", "project area (free-form, optional)")
-	c.Flags().String("status", "active", "active|temporary|deprecated")
-	c.Flags().String("review-after", "", "YYYY-MM-DD date to review (optional)")
-	c.Flags().String("body", "", "Markdown body (if omitted, read from stdin)")
-	c.Flags().StringSlice("files", nil, "related files, comma-separated (optional)")
+	c.Flags().String("title", "", i18n.T("short entry title (required)"))
+	c.Flags().String("platform", "", i18n.T("android|ios|shared|kmp|flutter|react-native (optional)"))
+	c.Flags().String("area", "", i18n.T("project area (free-form, optional)"))
+	c.Flags().String("status", "active", i18n.T("active|temporary|deprecated"))
+	c.Flags().String("review-after", "", i18n.T("YYYY-MM-DD date to review (optional)"))
+	c.Flags().String("body", "", i18n.T("Markdown body (if omitted, read from stdin)"))
+	c.Flags().StringSlice("files", nil, i18n.T("related files, comma-separated (optional)"))
 	_ = c.MarkFlagRequired("title")
 	return c
 }
@@ -675,7 +657,7 @@ func runBrainSave(c *cobra.Command, saveType brain.SaveType) error {
 		brain.SaveTypeTesting:  "testing.md",
 	}[saveType]
 	rel := filepath.Join(".mobiai", "brain", "memories", fileBase)
-	fmt.Fprintf(out, "✓ saved to %s\n  id: %s\n", rel, id)
+	fmt.Fprintf(out, i18n.T("✓ saved to %s\n  id: %s\n"), rel, id)
 	return nil
 }
 
@@ -710,11 +692,8 @@ func readPipedStdin(in io.Reader) (string, error) {
 func newBrainMCPCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "mcp",
-		Short: "Start an MCP server that exposes the Brain as tools",
-		Long: "Starts an MCP (Model Context Protocol) server that exposes the Brain's " +
-			"operations (context, search, scan, save) as tools the agent can invoke " +
-			"directly. Communicates over stdio — designed for an MCP client (Claude Code, " +
-			"Cursor, Copilot CLI, etc.) to launch it as a subprocess. See brain/MCP-SETUP.md.",
+		Short: i18n.T("Start an MCP server that exposes the Brain as tools"),
+		Long: i18n.T("Starts an MCP (Model Context Protocol) server that exposes the Brain's operations (context, search, scan, save) as tools the agent can invoke directly. Communicates over stdio — designed for an MCP client (Claude Code, Cursor, Copilot CLI, etc.) to launch it as a subprocess. See brain/MCP-SETUP.md."),
 		RunE: runBrainMCP,
 	}
 	brainCommonFlags(c)
@@ -738,19 +717,15 @@ func runBrainMCP(c *cobra.Command, _ []string) error {
 func newBrainInstallMCPCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "install-mcp",
-		Short: "Register the Brain MCP server in AI clients (Claude Code, Cursor)",
-		Long: "Adds the `mobiai-brain` server to each supported AI client's config, " +
-			"preserving the rest of the file. By default detects which clients are present " +
-			"(presence of ~/.claude or ~/.cursor); use --client to force a single one. " +
-			"Idempotent: re-running it with the same config is a no-op. Use --dry-run " +
-			"to preview without touching files, or --uninstall to remove the registration.",
+		Short: i18n.T("Register the Brain MCP server in AI clients (Claude Code, Cursor)"),
+		Long: i18n.T("Adds the `mobiai-brain` server to each supported AI client's config, preserving the rest of the file. By default detects which clients are present (presence of ~/.claude or ~/.cursor); use --client to force a single one. Idempotent: re-running it with the same config is a no-op. Use --dry-run to preview without touching files, or --uninstall to remove the registration."),
 		RunE: runBrainInstallMCP,
 	}
 	c.Flags().StringSlice("client", nil,
-		"clients to register: claude|cursor (repeatable or comma-separated; default: all detected)")
-	c.Flags().Bool("dry-run", false, "show which files would be touched without writing anything")
-	c.Flags().Bool("uninstall", false, "remove the registration instead of creating it")
-	c.Flags().String("binary", "", "path to the mobiai binary to register (default: the binary in use)")
+		i18n.T("clients to register: claude|cursor (repeatable or comma-separated; default: all detected)"))
+	c.Flags().Bool("dry-run", false, i18n.T("show which files would be touched without writing anything"))
+	c.Flags().Bool("uninstall", false, i18n.T("remove the registration instead of creating it"))
+	c.Flags().String("binary", "", i18n.T("path to the mobiai binary to register (default: the binary in use)"))
 	return c
 }
 
@@ -825,9 +800,9 @@ func printInstallResults(out io.Writer, results []brain.InstallResult, uninstall
 	if anyTouched && !results[0].DryRun {
 		fmt.Fprintln(out, "")
 		if uninstall {
-			fmt.Fprintln(out, "Done. Restart the client for changes to take effect.")
+			fmt.Fprintln(out, i18n.T("Done. Restart the client for changes to take effect."))
 		} else {
-			fmt.Fprintln(out, "Done. Restart the client so it loads the MCP server.")
+			fmt.Fprintln(out, i18n.T("Done. Restart the client so it loads the MCP server."))
 		}
 	}
 }
@@ -835,17 +810,17 @@ func printInstallResults(out io.Writer, results []brain.InstallResult, uninstall
 func installIconAndLabel(a brain.InstallAction) (string, string) {
 	switch a {
 	case brain.ActionInstalled:
-		return "✓", "registered"
+		return "✓", i18n.T("registered")
 	case brain.ActionUpdated:
-		return "✓", "updated"
+		return "✓", i18n.T("updated")
 	case brain.ActionUnchanged:
-		return "=", "unchanged (already registered)"
+		return "=", i18n.T("unchanged (already registered)")
 	case brain.ActionUninstalled:
-		return "✓", "removed"
+		return "✓", i18n.T("removed")
 	case brain.ActionNotPresent:
-		return "=", "was not registered"
+		return "=", i18n.T("was not registered")
 	case brain.ActionSkipped:
-		return "·", "skipped (client not installed)"
+		return "·", i18n.T("skipped (client not installed)")
 	}
 	return "?", string(a)
 }

--- a/cli/internal/cmd/catalog.go
+++ b/cli/internal/cmd/catalog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/catalog"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/resolver"
 )
 
@@ -17,19 +18,19 @@ import (
 func NewCatalogCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:    "catalog",
-		Short:  "Inspect the catalog (debug)",
-		Long:   "Hidden subcommand for catalog/resolver smoke tests. Not intended for end users.",
+		Short:  i18n.T("Inspect the catalog (debug)"),
+		Long:   i18n.T("Hidden subcommand for catalog/resolver smoke tests. Not intended for end users."),
 		Hidden: true,
 	}
 
 	var rootFlag string
 	addRootFlag := func(c *cobra.Command) {
-		c.Flags().StringVar(&rootFlag, "root", ".", "Path to the catalog root (directory containing .claude-plugin/marketplace.json)")
+		c.Flags().StringVar(&rootFlag, "root", ".", i18n.T("Path to the catalog root (directory containing .claude-plugin/marketplace.json)"))
 	}
 
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: "List the packs in the catalog",
+		Short: i18n.T("List the packs in the catalog"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root := rootFlag
 			if root == "" || root == "." {
@@ -42,10 +43,10 @@ func NewCatalogCmd() *cobra.Command {
 				return err
 			}
 			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "Catalog: %s (version %s)\n", c.Marketplace.Name, c.Marketplace.Metadata.Version)
+			fmt.Fprintf(out, i18n.T("Catalog: %s (version %s)\n"), c.Marketplace.Name, c.Marketplace.Metadata.Version)
 			fmt.Fprintf(out, "Packs (%d):\n", len(c.Packs))
 			for _, p := range c.Packs {
-				deps := "none"
+				deps := i18n.T("none")
 				if len(p.Manifest.Dependencies) > 0 {
 					deps = strings.Join(p.Manifest.Dependencies, ", ")
 				}
@@ -58,7 +59,7 @@ func NewCatalogCmd() *cobra.Command {
 
 	resolveCmd := &cobra.Command{
 		Use:   "resolve <pack>...",
-		Short: "Resolve the install order for the given packs",
+		Short: i18n.T("Resolve the install order for the given packs"),
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root := rootFlag
@@ -76,7 +77,7 @@ func NewCatalogCmd() *cobra.Command {
 				return err
 			}
 			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "Install order:\n")
+			fmt.Fprint(out, i18n.T("Install order:\n"))
 			for i, name := range order {
 				fmt.Fprintf(out, "  %d. %s\n", i+1, name)
 			}

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -5,24 +5,25 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 )
 
 func NewDoctorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",
-		Short: "Thorough diagnostics for CLI, hosts and catalog",
+		Short: i18n.T("Thorough diagnostics for CLI, hosts and catalog"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "MobiAI %s — diagnostics\n\n", version)
+			fmt.Fprintf(out, i18n.T("MobiAI %s — diagnostics\n\n"), version)
 
-			fmt.Fprintln(out, "Supported hosts:")
+			fmt.Fprintln(out, i18n.T("Supported hosts:"))
 			g := flagsFromAnyCmd(cmd)
 			r := newRegistry(g)
 			for _, a := range r.Adapters() {
 				det := a.Detect()
 				marker := "-"
-				note := "not detected"
+				note := i18n.T("not detected")
 				if det.Found {
 					marker = "✓"
 					note = "OK"
@@ -39,16 +40,16 @@ func NewDoctorCmd() *cobra.Command {
 				return err
 			}
 			meta, _ := state.LoadMeta(paths)
-			fmt.Fprintln(out, "Catalog:")
+			fmt.Fprintln(out, i18n.T("Catalog:"))
 			if meta.LastSync.IsZero() {
-				fmt.Fprintln(out, "  (never synced)")
+				fmt.Fprintln(out, i18n.T("  (never synced)"))
 			} else {
-				fmt.Fprintf(out, "  Last sync: %s\n", meta.LastSync.Format("2006-01-02 15:04:05"))
-				fmt.Fprintf(out, "  Version:   %s\n", meta.Version)
+				fmt.Fprintf(out, i18n.T("  Last sync: %s\n"), meta.LastSync.Format("2006-01-02 15:04:05"))
+				fmt.Fprintf(out, i18n.T("  Version:   %s\n"), meta.Version)
 			}
 			fmt.Fprintln(out)
 
-			fmt.Fprintln(out, "Drift check:")
+			fmt.Fprintln(out, i18n.T("Drift check:"))
 			anyDrift := false
 			for _, a := range r.Detect() {
 				rep := a.Verify()
@@ -60,7 +61,7 @@ func NewDoctorCmd() *cobra.Command {
 				}
 			}
 			if !anyDrift {
-				fmt.Fprintln(out, "  ✓ no drift detected (Verify is a stub in this version)")
+				fmt.Fprintln(out, i18n.T("  ✓ no drift detected (Verify is a stub in this version)"))
 			}
 			return nil
 		},

--- a/cli/internal/cmd/flags.go
+++ b/cli/internal/cmd/flags.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 )
 
 // GlobalFlags hold the persistent flags shared across all subcommands.
@@ -17,12 +19,12 @@ type GlobalFlags struct {
 
 // AddPersistentFlags attaches the global flags to the root command.
 func AddPersistentFlags(root *cobra.Command) {
-	root.PersistentFlags().StringSliceP("host", "", nil, "force specific adapters (default: all detected)")
-	root.PersistentFlags().BoolP("yes", "y", false, "assume yes on confirmations (CI-friendly)")
-	root.PersistentFlags().BoolP("verbose", "V", false, "more output (currently only affects 'mobiai update')")
-	root.PersistentFlags().Bool("no-color", false, "disable ANSI colors in help output")
-	root.PersistentFlags().String("catalog-root", "", "path to a local catalog (overrides ~/.mobiai/cache/catalog)")
-	root.PersistentFlags().Bool("include-experimental", false, "include tier-3 adapters (speculative paths) in auto-detection")
+	root.PersistentFlags().StringSliceP("host", "", nil, i18n.T("force specific adapters (default: all detected)"))
+	root.PersistentFlags().BoolP("yes", "y", false, i18n.T("assume yes on confirmations (CI-friendly)"))
+	root.PersistentFlags().BoolP("verbose", "V", false, i18n.T("more output (currently only affects 'mobiai update')"))
+	root.PersistentFlags().Bool("no-color", false, i18n.T("disable ANSI colors in help output"))
+	root.PersistentFlags().String("catalog-root", "", i18n.T("path to a local catalog (overrides ~/.mobiai/cache/catalog)"))
+	root.PersistentFlags().Bool("include-experimental", false, i18n.T("include tier-3 adapters (speculative paths) in auto-detection"))
 }
 
 // FlagsFromCmd extracts the global flags from a cobra command's flag set.

--- a/cli/internal/cmd/graph.go
+++ b/cli/internal/cmd/graph.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/graph"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 )
 
 // NewGraphCmd builds `mobiai graph <init|status|search|callers|context>`.
@@ -20,9 +21,8 @@ import (
 func NewGraphCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "graph",
-		Short: "Semantic exploration of mobile code",
-		Long: "MobiAI Graph indexes the project and lets you search symbols, find references, " +
-			"and get relevant context for a task. Lives at <repo>/.mobiai/graph/.",
+		Short: i18n.T("Semantic exploration of mobile code"),
+		Long:  i18n.T("MobiAI Graph indexes the project and lets you search symbols, find references, and get relevant context for a task. Lives at <repo>/.mobiai/graph/."),
 	}
 	root.AddCommand(
 		newGraphInitCmd(),
@@ -37,7 +37,7 @@ func NewGraphCmd() *cobra.Command {
 // graphCommonFlags wires up the shared --root flag on a leaf command.
 // When omitted, the command resolves the project root from cwd.
 func graphCommonFlags(c *cobra.Command) {
-	c.Flags().String("root", "", "project path (default: cwd)")
+	c.Flags().String("root", "", i18n.T("project path (default: cwd)"))
 }
 
 // resolveGraphRoot returns the absolute project root for a graph command.
@@ -86,7 +86,7 @@ func loadGraphIndex(root string) (*graph.Index, string, error) {
 func newGraphInitCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "init",
-		Short: "Index the project and save .mobiai/graph/index.json",
+		Short: i18n.T("Index the project and save .mobiai/graph/index.json"),
 		RunE:  runGraphInit,
 	}
 	graphCommonFlags(c)
@@ -113,18 +113,18 @@ func runGraphInit(c *cobra.Command, _ []string) error {
 	kotlin, swift := countByLanguage(idx)
 	symbols := countSymbols(idx)
 
-	fmt.Fprintf(out, "✓ Index generated: %s\n", path)
-	fmt.Fprintf(out, "  Files:   %d\n", len(idx.Files))
-	fmt.Fprintf(out, "  Symbols: %d\n", symbols)
-	fmt.Fprintf(out, "  Kotlin:  %d\n", kotlin)
-	fmt.Fprintf(out, "  Swift:   %d\n", swift)
+	fmt.Fprintf(out, i18n.T("✓ Index generated: %s\n"), path)
+	fmt.Fprintf(out, i18n.T("  Files:   %d\n"), len(idx.Files))
+	fmt.Fprintf(out, i18n.T("  Symbols: %d\n"), symbols)
+	fmt.Fprintf(out, i18n.T("  Kotlin:  %d\n"), kotlin)
+	fmt.Fprintf(out, i18n.T("  Swift:   %d\n"), swift)
 	return nil
 }
 
 func newGraphStatusCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "status",
-		Short: "Show info about the current index",
+		Short: i18n.T("Show info about the current index"),
 		RunE:  runGraphStatus,
 	}
 	graphCommonFlags(c)
@@ -145,26 +145,26 @@ func runGraphStatus(c *cobra.Command, _ []string) error {
 	kotlin, swift := countByLanguage(idx)
 	symbols := countSymbols(idx)
 
-	fmt.Fprintf(out, "Index:     %s\n", path)
-	fmt.Fprintf(out, "Generated: %s (%s)\n",
+	fmt.Fprintf(out, i18n.T("Index:     %s\n"), path)
+	fmt.Fprintf(out, i18n.T("Generated: %s (%s)\n"),
 		idx.GeneratedAt.Format(time.RFC3339), humanizeAge(idx.GeneratedAt))
-	fmt.Fprintf(out, "Files:     %d\n", len(idx.Files))
-	fmt.Fprintf(out, "Symbols:   %d\n", symbols)
-	fmt.Fprintf(out, "Kotlin:    %d\n", kotlin)
-	fmt.Fprintf(out, "Swift:     %d\n", swift)
+	fmt.Fprintf(out, i18n.T("Files:     %d\n"), len(idx.Files))
+	fmt.Fprintf(out, i18n.T("Symbols:   %d\n"), symbols)
+	fmt.Fprintf(out, i18n.T("Kotlin:    %d\n"), kotlin)
+	fmt.Fprintf(out, i18n.T("Swift:     %d\n"), swift)
 	return nil
 }
 
 func newGraphSearchCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "search <term>",
-		Short: "Search symbols by name",
+		Short: i18n.T("Search symbols by name"),
 		Args:  cobra.ExactArgs(1),
 		RunE:  runGraphSearch,
 	}
 	graphCommonFlags(c)
-	c.Flags().Int("limit", 0, "max results to show (0 = no limit)")
-	c.Flags().String("kind", "", "filter by symbol kind (class, fun, object, interface, struct, enum, protocol, actor, func, extension)")
+	c.Flags().Int("limit", 0, i18n.T("max results to show (0 = no limit)"))
+	c.Flags().String("kind", "", i18n.T("filter by symbol kind (class, fun, object, interface, struct, enum, protocol, actor, func, extension)"))
 	return c
 }
 
@@ -198,7 +198,7 @@ func runGraphSearch(c *cobra.Command, args []string) error {
 	}
 
 	if len(hits) == 0 {
-		fmt.Fprintln(out, "No matches.")
+		fmt.Fprintln(out, i18n.T("No matches."))
 		return nil
 	}
 
@@ -212,7 +212,7 @@ func runGraphSearch(c *cobra.Command, args []string) error {
 		fmt.Fprintf(out, "%s:%d %s %s\n", h.File, h.Symbol.Line, h.Symbol.Kind, h.Symbol.Name)
 	}
 	if truncated {
-		fmt.Fprintf(out, "… (showing %d, use --limit 0 to see all)\n", limit)
+		fmt.Fprintf(out, i18n.T("… (showing %d, use --limit 0 to see all)\n"), limit)
 	}
 	return nil
 }
@@ -220,7 +220,7 @@ func runGraphSearch(c *cobra.Command, args []string) error {
 func newGraphCallersCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "callers <symbol>",
-		Short: "List textual references to the symbol",
+		Short: i18n.T("List textual references to the symbol"),
 		Args:  cobra.ExactArgs(1),
 		RunE:  runGraphCallers,
 	}
@@ -240,7 +240,7 @@ func runGraphCallers(c *cobra.Command, args []string) error {
 	}
 	hits := graph.Callers(idx, root, args[0])
 	if len(hits) == 0 {
-		fmt.Fprintln(out, "No references.")
+		fmt.Fprintln(out, i18n.T("No references."))
 		return nil
 	}
 	for _, h := range hits {
@@ -252,7 +252,7 @@ func runGraphCallers(c *cobra.Command, args []string) error {
 func newGraphContextCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "context <task...>",
-		Short: "Relevant files for a task (heuristic)",
+		Short: i18n.T("Relevant files for a task (heuristic)"),
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  runGraphContext,
 	}
@@ -273,7 +273,7 @@ func runGraphContext(c *cobra.Command, args []string) error {
 	task := joinArgs(args)
 	hits := graph.Context(idx, task, 10)
 	if len(hits) == 0 {
-		fmt.Fprintln(out, "No relevant files found.")
+		fmt.Fprintln(out, i18n.T("No relevant files found."))
 		return nil
 	}
 	for _, h := range hits {
@@ -328,12 +328,12 @@ func humanizeAge(t time.Time) string {
 	}
 	if d < time.Hour {
 		mins := int(d.Round(time.Minute) / time.Minute)
-		return fmt.Sprintf("%dm ago", mins)
+		return fmt.Sprintf(i18n.T("%dm ago"), mins)
 	}
 	if d < 24*time.Hour {
 		hours := int(d.Round(time.Hour) / time.Hour)
-		return fmt.Sprintf("%dh ago", hours)
+		return fmt.Sprintf(i18n.T("%dh ago"), hours)
 	}
 	days := int(d.Round(24*time.Hour) / (24 * time.Hour))
-	return fmt.Sprintf("%dd ago", days)
+	return fmt.Sprintf(i18n.T("%dd ago"), days)
 }

--- a/cli/internal/cmd/hosts.go
+++ b/cli/internal/cmd/hosts.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/host"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 )
 
 // NewHostsCmd builds the hidden `mobiai hosts` debug command tree.
@@ -15,22 +16,22 @@ import (
 func NewHostsCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:    "hosts",
-		Short:  "Inspect supported hosts (debug)",
-		Long:   "Hidden subcommand for hosts-registry smoke tests. Not intended for end users.",
+		Short:  i18n.T("Inspect supported hosts (debug)"),
+		Long:   i18n.T("Hidden subcommand for hosts-registry smoke tests. Not intended for end users."),
 		Hidden: true,
 	}
 
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: "List supported hosts and which are detected",
+		Short: i18n.T("List supported hosts and which are detected"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := host.NewDefaultRegistry()
 			out := cmd.OutOrStdout()
 			adapters := r.Adapters()
-			fmt.Fprintf(out, "Supported hosts (%d adapters loaded):\n", len(adapters))
+			fmt.Fprintf(out, i18n.T("Supported hosts (%d adapters loaded):\n"), len(adapters))
 			for _, a := range adapters {
 				det := a.Detect()
-				marker, status, path := "-", "not detected", ""
+				marker, status, path := "-", i18n.T("not detected"), ""
 				if det.Found {
 					marker, status, path = "✓", "OK", det.Path
 				} else if len(det.Searched) > 0 {

--- a/cli/internal/cmd/lang.go
+++ b/cli/internal/cmd/lang.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
+)
+
+// NewLangCmd builds `mobiai lang`: with no args it prints the active language;
+// with `en`/`es` it persists the choice to <home>/config.json. The preference
+// is applied at the next startup via i18n.Init (and immediately for the
+// confirmation message below).
+func NewLangCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "lang [en|es]",
+		Short: i18n.T("Show or set the CLI language (en/es)"),
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+
+			if len(args) == 0 {
+				fmt.Fprintf(out, i18n.T("Current language: %s\n"), i18n.Current())
+				return nil
+			}
+
+			lang, ok := i18n.Parse(args[0])
+			if !ok {
+				return fmt.Errorf("unsupported language %q (supported: en, es)", args[0])
+			}
+
+			paths, err := state.NewPaths()
+			if err != nil {
+				return err
+			}
+			cfg, err := state.LoadConfig(paths)
+			if err != nil {
+				return err
+			}
+			cfg.Lang = string(lang)
+			if err := cfg.Save(paths); err != nil {
+				return err
+			}
+
+			i18n.SetLang(lang) // so the confirmation prints in the new language
+			fmt.Fprintf(out, i18n.T("Language set to %s.\n"), lang)
+			return nil
+		},
+	}
+}

--- a/cli/internal/cmd/lang.go
+++ b/cli/internal/cmd/lang.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -22,7 +23,13 @@ func NewLangCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 
 			if len(args) == 0 {
+				langs := make([]string, 0, len(i18n.Supported()))
+				for _, l := range i18n.Supported() {
+					langs = append(langs, string(l))
+				}
 				fmt.Fprintf(out, i18n.T("Current language: %s\n"), i18n.Current())
+				fmt.Fprintf(out, i18n.T("Available:        %s\n"), strings.Join(langs, ", "))
+				fmt.Fprint(out, i18n.T("Change it with `mobiai lang en` or `mobiai lang es`.\n"))
 				return nil
 			}
 

--- a/cli/internal/cmd/lang_test.go
+++ b/cli/internal/cmd/lang_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
+)
+
+func TestLang_ShowDefault(t *testing.T) {
+	t.Cleanup(func() { i18n.SetLang(i18n.EN) })
+	i18n.SetLang(i18n.EN)
+
+	cmd := NewLangCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Current language: en") {
+		t.Errorf("expected current language en; got %q", out.String())
+	}
+}
+
+func TestLang_SetPersistsAndConfirmsInNewLang(t *testing.T) {
+	t.Cleanup(func() { i18n.SetLang(i18n.EN) })
+	tmp := t.TempDir()
+	t.Setenv("MOBIAI_HOME", filepath.Join(tmp, ".mobiai"))
+	i18n.SetLang(i18n.EN)
+
+	cmd := NewLangCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"es"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The confirmation prints in the NEW language (lang switched before print).
+	if !strings.Contains(out.String(), "Idioma cambiado a es") {
+		t.Errorf("confirmation should be in es; got %q", out.String())
+	}
+
+	// The choice persisted to config.json.
+	p, _ := state.NewPaths()
+	cfg, err := state.LoadConfig(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Lang != "es" {
+		t.Errorf("persisted Lang: got %q, want es", cfg.Lang)
+	}
+}
+
+func TestLang_InvalidRejected(t *testing.T) {
+	t.Cleanup(func() { i18n.SetLang(i18n.EN) })
+
+	cmd := NewLangCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"fr"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected an error for an unsupported language")
+	}
+}

--- a/cli/internal/cmd/selfupdate.go
+++ b/cli/internal/cmd/selfupdate.go
@@ -16,6 +16,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 )
 
 // defaultInstallBase is the GitHub Releases base URL. Release assets live at
@@ -50,7 +52,7 @@ func selfUpdateBinary(out io.Writer, currentVersion string) error {
 	if err := selfReplace(bin); err != nil {
 		return fmt.Errorf("install new binary: %w", err)
 	}
-	fmt.Fprintf(out, "mobiai binary updated to %s. Restart your terminal (or re-run mobiai) to use the new version.\n", latest)
+	fmt.Fprintf(out, i18n.T("mobiai binary updated to %s. Restart your terminal (or re-run mobiai) to use the new version.\n"), latest)
 	return nil
 }
 
@@ -74,7 +76,7 @@ func fetchUpdateBinary(out io.Writer, currentVersion string) (bin []byte, latest
 		return nil, "", fmt.Errorf("query releases: %w", err)
 	}
 	if !semverLess(currentVersion, latest) {
-		fmt.Fprintf(out, "mobiai binary %s: up to date.\n", currentVersion)
+		fmt.Fprintf(out, i18n.T("mobiai binary %s: up to date.\n"), currentVersion)
 		return nil, "", nil
 	}
 
@@ -83,7 +85,7 @@ func fetchUpdateBinary(out io.Writer, currentVersion string) (bin []byte, latest
 		base = defaultInstallBase
 	}
 	archive := assetName(latest, runtime.GOOS, runtime.GOARCH)
-	fmt.Fprintf(out, "mobiai binary %s → %s: downloading %s...\n", currentVersion, latest, archive)
+	fmt.Fprintf(out, i18n.T("mobiai binary %s → %s: downloading %s...\n"), currentVersion, latest, archive)
 
 	archiveURL := fmt.Sprintf("%s/download/cli-v%s/%s", base, latest, archive)
 	data, err := downloadBytes(archiveURL)

--- a/cli/internal/cmd/skills.go
+++ b/cli/internal/cmd/skills.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/catalog"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/embedded"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/host"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/resolver"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/tui"
@@ -26,18 +27,18 @@ import (
 func NewSkillsCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "skills",
-		Short: "Manage MobiAI skills",
+		Short: i18n.T("Manage MobiAI skills"),
 	}
 	// When invoked standalone (in tests), register the persistent flags
 	// locally so callers can pass --catalog-root and --yes without going
 	// through the root command's persistent flag set.
-	root.PersistentFlags().StringSlice("host", nil, "force specific adapters (default: all detected)")
-	root.PersistentFlags().Bool("yes", false, "assume yes on confirmations")
-	root.PersistentFlags().String("catalog-root", "", "path to a local catalog")
+	root.PersistentFlags().StringSlice("host", nil, i18n.T("force specific adapters (default: all detected)"))
+	root.PersistentFlags().Bool("yes", false, i18n.T("assume yes on confirmations"))
+	root.PersistentFlags().String("catalog-root", "", i18n.T("path to a local catalog"))
 
 	addCmd := &cobra.Command{
 		Use:   "add <pack>...",
-		Short: "Install packs into detected hosts",
+		Short: i18n.T("Install packs into detected hosts"),
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSkillsAdd(cmd, args)
@@ -45,7 +46,7 @@ func NewSkillsCmd() *cobra.Command {
 	}
 	removeCmd := &cobra.Command{
 		Use:   "remove <pack>...",
-		Short: "Uninstall packs from detected hosts",
+		Short: i18n.T("Uninstall packs from detected hosts"),
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSkillsRemove(cmd, args)
@@ -54,7 +55,7 @@ func NewSkillsCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: "List installed packs",
+		Short: i18n.T("List installed packs"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths, err := state.NewPaths()
 			if err != nil {
@@ -66,7 +67,7 @@ func NewSkillsCmd() *cobra.Command {
 			}
 			out := cmd.OutOrStdout()
 			if len(installed.Packs) == 0 {
-				fmt.Fprintln(out, "No packs installed.")
+				fmt.Fprintln(out, i18n.T("No packs installed."))
 				return nil
 			}
 			fmt.Fprintln(out, "Pack          | Hosts")
@@ -85,8 +86,8 @@ func NewSkillsCmd() *cobra.Command {
 
 	initCmd := &cobra.Command{
 		Use:   "init",
-		Short: "Interactive picker to install/uninstall skills",
-		Long:  "Launches the TUI picker to choose skill packs and apply changes to detected clients (Claude Code, Cursor, Codex, etc).",
+		Short: i18n.T("Interactive picker to install/uninstall skills"),
+		Long:  i18n.T("Launches the TUI picker to choose skill packs and apply changes to detected clients (Claude Code, Cursor, Codex, etc)."),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			g := flagsFromAnyCmd(cmd)
 			if err := RunPicker(g); err != nil {
@@ -139,7 +140,7 @@ func runSkillsAdd(cmd *cobra.Command, packs []string) error {
 			return err
 		}
 		if !ok {
-			fmt.Fprintln(out, "Cancelled.")
+			fmt.Fprintln(out, i18n.T("Cancelled."))
 			return nil
 		}
 	}
@@ -161,7 +162,7 @@ func runSkillsAdd(cmd *cobra.Command, packs []string) error {
 	if err := installed.Save(paths); err != nil {
 		return err
 	}
-	fmt.Fprintln(out, "Done.")
+	fmt.Fprintln(out, i18n.T("Done."))
 	return nil
 }
 
@@ -174,7 +175,7 @@ func confirmInstall(out io.Writer, in io.Reader, packs []string, hosts []host.Ho
 	for _, h := range hosts {
 		hostNames = append(hostNames, h.Name())
 	}
-	fmt.Fprintln(out, "Install plan:")
+	fmt.Fprintln(out, i18n.T("Install plan:"))
 	fmt.Fprintf(out, "  Packs (%d): %s\n", len(packs), strings.Join(packs, ", "))
 	fmt.Fprintf(out, "  Hosts (%d): %s\n", len(hosts), strings.Join(hostNames, ", "))
 
@@ -182,7 +183,7 @@ func confirmInstall(out io.Writer, in io.Reader, packs []string, hosts []host.Ho
 		return false, fmt.Errorf("stdin is not interactive: pass --yes to confirm without a prompt")
 	}
 
-	fmt.Fprint(out, "Continue? [y/N]: ")
+	fmt.Fprint(out, i18n.T("Continue? [y/N]: "))
 	r := bufio.NewReader(in)
 	line, err := r.ReadString('\n')
 	if err != nil && err != io.EOF {
@@ -237,7 +238,7 @@ func runSkillsRemove(cmd *cobra.Command, packs []string) error {
 	if err := installed.Save(paths); err != nil {
 		return err
 	}
-	fmt.Fprintln(out, "Done.")
+	fmt.Fprintln(out, i18n.T("Done."))
 	return nil
 }
 

--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 )
 
@@ -20,7 +21,7 @@ func SetVersion(v string) { version = v }
 func NewStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
-		Short: "Summary of detected hosts, installed packs and catalog state",
+		Short: i18n.T("Summary of detected hosts, installed packs and catalog state"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			fmt.Fprintf(out, "MobiAI %s\n\n", version)
@@ -30,7 +31,7 @@ func NewStatusCmd() *cobra.Command {
 			present := r.Detect()
 			fmt.Fprintln(out, "Hosts:")
 			if len(present) == 0 {
-				fmt.Fprintln(out, "  (none detected — install Claude Code, Cursor, Gemini CLI, Codex, or another agentskills.io-compatible client)")
+				fmt.Fprintln(out, i18n.T("  (none detected — install Claude Code, Cursor, Gemini CLI, Codex, or another agentskills.io-compatible client)"))
 			} else {
 				for _, a := range present {
 					det := a.Detect()
@@ -51,9 +52,9 @@ func NewStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(out, "Installed packs:")
+			fmt.Fprintln(out, i18n.T("Installed packs:"))
 			if len(installed.Packs) == 0 {
-				fmt.Fprintln(out, "  (none)")
+				fmt.Fprintln(out, i18n.T("  (none)"))
 			} else {
 				names := make([]string, 0, len(installed.Packs))
 				for n := range installed.Packs {

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/catalog"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 )
 
@@ -23,7 +24,7 @@ const defaultCatalogGitURL = "https://github.com/ArisGuimera/MobiAI-Core.git"
 func NewUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Refresh the catalog from the remote (or a local path with --catalog-root)",
+		Short: i18n.T("Refresh the catalog from the remote (or a local path with --catalog-root)"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			g := flagsFromAnyCmd(cmd)
@@ -84,26 +85,26 @@ func NewUpdateCmd() *cobra.Command {
 			if err := meta.Save(paths); err != nil {
 				return err
 			}
-			fmt.Fprintf(out, "Skills catalog updated to v%s.\n", meta.Version)
-			fmt.Fprintf(out, "%d packs available at %s.\n", len(c.Packs), rootFlag)
+			fmt.Fprintf(out, i18n.T("Skills catalog updated to v%s.\n"), meta.Version)
+			fmt.Fprintf(out, i18n.T("%d packs available at %s.\n"), len(c.Packs), rootFlag)
 
 			// Catalog is refreshed; now update the binary itself if a newer
 			// release exists. A binary-update failure is non-fatal: the
 			// catalog sync above already succeeded, so we warn and exit 0.
 			if skip, _ := cmd.Flags().GetBool("skip-binary"); skip {
-				fmt.Fprintf(out, "mobiai binary: %s (--skip-binary, did not check for an update).\n", version)
+				fmt.Fprintf(out, i18n.T("mobiai binary: %s (--skip-binary, did not check for an update).\n"), version)
 			} else if err := selfUpdateBinary(out, version); err != nil {
-				fmt.Fprintf(out, "Warning: the catalog was updated, but the binary could not be updated: %v\n", err)
-				fmt.Fprintf(out, "Retry `mobiai update` later, or reinstall with the install script: https://mobiai.dev\n")
+				fmt.Fprintf(out, i18n.T("Warning: the catalog was updated, but the binary could not be updated: %v\n"), err)
+				fmt.Fprint(out, i18n.T("Retry `mobiai update` later, or reinstall with the install script: https://mobiai.dev\n"))
 			}
 			return nil
 		},
 	}
-	cmd.Flags().String("catalog-root", "", "path to a local catalog (override)")
-	cmd.Flags().Bool("force", false, "if the cache dir exists but is not a git repo, delete it and re-clone")
-	cmd.Flags().Bool("check", false, "only query GitHub releases and cache the result (does not touch the catalog)")
-	cmd.Flags().Bool("silent", false, "print nothing on exit (intended for running from a background hook)")
-	cmd.Flags().Bool("skip-binary", false, "do not update the mobiai binary, only refresh the catalog")
+	cmd.Flags().String("catalog-root", "", i18n.T("path to a local catalog (override)"))
+	cmd.Flags().Bool("force", false, i18n.T("if the cache dir exists but is not a git repo, delete it and re-clone"))
+	cmd.Flags().Bool("check", false, i18n.T("only query GitHub releases and cache the result (does not touch the catalog)"))
+	cmd.Flags().Bool("silent", false, i18n.T("print nothing on exit (intended for running from a background hook)"))
+	cmd.Flags().Bool("skip-binary", false, i18n.T("do not update the mobiai binary, only refresh the catalog"))
 	return cmd
 }
 
@@ -137,7 +138,7 @@ func syncRemoteCatalog(out io.Writer, url, cacheRoot string, verbose, force bool
 	dotGit := filepath.Join(cacheRoot, ".git")
 	if _, err := os.Stat(dotGit); err == nil {
 		// Already cloned — pull.
-		fmt.Fprintf(out, "Syncing catalog (git pull)...\n")
+		fmt.Fprint(out, i18n.T("Syncing catalog (git pull)...\n"))
 		c := exec.Command("git", "-C", cacheRoot, "pull", "--ff-only")
 		buf := configureCmdIO(c)
 		if err := c.Run(); err != nil {
@@ -167,7 +168,7 @@ func syncRemoteCatalog(out io.Writer, url, cacheRoot string, verbose, force bool
 			return fmt.Errorf("clean %s: %w", cacheRoot, err)
 		}
 	}
-	fmt.Fprintf(out, "Cloning catalog from %s...\n", url)
+	fmt.Fprintf(out, i18n.T("Cloning catalog from %s...\n"), url)
 	c := exec.Command("git", "clone", "--depth=1", url, cacheRoot)
 	buf := configureCmdIO(c)
 	if err := c.Run(); err != nil {

--- a/cli/internal/cmd/updatecheck.go
+++ b/cli/internal/cmd/updatecheck.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 )
 
 // updateCheckCache is the on-disk record consumed by the SessionStart hooks
@@ -86,9 +88,9 @@ func runUpdateCheck(out io.Writer, installedVersion string) error {
 	}
 
 	if available {
-		fmt.Fprintf(out, "MobiAI %s → %s available. Run: mobiai update\n", installedVersion, latest)
+		fmt.Fprintf(out, i18n.T("MobiAI %s → %s available. Run: mobiai update\n"), installedVersion, latest)
 	} else if out != io.Discard {
-		fmt.Fprintf(out, "MobiAI %s is up to date (latest release: %s).\n", installedVersion, latest)
+		fmt.Fprintf(out, i18n.T("MobiAI %s is up to date (latest release: %s).\n"), installedVersion, latest)
 	}
 	return nil
 }

--- a/cli/internal/i18n/catalog_brain_es.go
+++ b/cli/internal/i18n/catalog_brain_es.go
@@ -1,0 +1,100 @@
+package i18n
+
+func init() {
+	registerES(map[string]string{
+		// ── internal/cmd/brain.go ────────────────────────────────────────────
+		// root + brainCommonFlags
+		"Per-project memory for mobile agents": "Memoria por proyecto para agentes mobile",
+		"MobiAI Brain stores living per-project context: detected stack, decisions, bugfixes, testing patterns and integrations. Lives at <repo>/.mobiai/brain/ — separate from the CLI's global state.": "MobiAI Brain guarda contexto vivo por proyecto: stack detectado, decisiones, bugfixes, patrones de testing e integraciones. Vive en <repo>/.mobiai/brain/ — separado del estado global de la CLI.",
+		"project path (default: detected from cwd)": "ruta del proyecto (default: detectado desde el cwd)",
+
+		// init
+		"Initialize .mobiai/brain in the current project":     "Inicializa .mobiai/brain en el proyecto actual",
+		"⚠ %s (using %s)\n":                                   "⚠ %s (usando %s)\n",
+		"Detected project: %s\n":                              "Proyecto detectado: %s\n",
+		"✓ created %s\n":                                      "✓ creado %s\n",
+		"= %s already exists (not overwritten)\n":             "= %s ya existe (no se sobrescribe)\n",
+		"✓ memories initialized: %s\n":                        "✓ memorias inicializadas: %s\n",
+		"= memories already exist (not overwritten)":          "= memorias ya existentes (no se sobrescriben)",
+		"Next step: `mobiai brain scan` to detect the stack.": "Siguiente paso: `mobiai brain scan` para detectar el stack.",
+
+		// scan
+		"Scan the project and detect the mobile stack": "Escanea el proyecto y detecta el stack mobile",
+		"Scanning %s ...\n":                            "Escaneando %s ...\n",
+		"✓ scan saved to %s\n":                         "✓ scan guardado en %s\n",
+
+		// context
+		"Print the Brain's Markdown context (config + scan + memories)": "Imprime el contexto Markdown del Brain (config + scan + memorias)",
+		"Prints the Brain context as Markdown. Without flags, dumps everything. With --section, --platform, --status or --area, filters memory entries so only what's relevant appears (useful as the brain grows).": "Imprime el contexto del Brain como Markdown. Sin flags, vuelca todo. Con --section, --platform, --status o --area filtra entradas de las memorias para que solo aparezca lo relevante (útil cuando el brain crece).",
+		"limit sections to render (stack,rules,decisions,bugfixes,testing,integrations,releases,warnings). Repeatable or comma-separated.":                                                                           "limita las secciones a renderizar (stack,rules,decisions,bugfixes,testing,integrations,releases,warnings). Repetible o coma-separado.",
+		"filter entries by platform (android|ios|shared|kmp|flutter|react-native)":                                                                                                                                   "filtra entradas por platform (android|ios|shared|kmp|flutter|react-native)",
+		"filter entries by status (active|temporary|deprecated)":                                                                                                                                                     "filtra entradas por status (active|temporary|deprecated)",
+		"filter entries whose area contains this string (substring)":                                                                                                                                                 "filtra entradas cuyo area contenga este string (substring)",
+
+		// search
+		"Free-text search across Brain memories": "Busca texto libre en las memorias del Brain",
+		"Performs a case-insensitive match against the title and body of each memory entry. The --platform/--status/--area flags filter results with AND semantics.": "Hace match case-insensitive sobre el título y el cuerpo de cada entrada de las memorias. Los flags --platform/--status/--area filtran los resultados con semántica AND.",
+		"limit to entries with this platform":              "limita a entradas con este platform",
+		"limit to entries with this status":                "limita a entradas con este status",
+		"limit to entries whose area contains this string": "limita a entradas cuya area contenga este string",
+		"No results for %q.\n":                             "Sin resultados para %q.\n",
+		"%d result(s) for %q:\n\n":                         "%d resultado(s) para %q:\n\n",
+
+		// review
+		"List temporary entries whose review_after has passed": "Lista entradas temporales cuyo review_after ya pasó",
+		"Walks the memories and shows entries with status: temporary whose review_after <= today. Designed to keep temporary workarounds from drifting into permanence by inertia. By default exits with status 1 if there are overdue entries (useful as a CI / pre-commit gate); pass --no-fail to only report. With --include-no-date it also lists temporary entries without a review_after assigned.": "Recorre las memorias y muestra las entradas con status: temporary cuyo review_after <= hoy. Pensado para evitar que workarounds temporales se vuelvan permanentes por inercia. Por defecto sale con exit 1 si hay vencidas (útil como gate en CI / pre-commit); usá --no-fail para que solo informe. Con --include-no-date también lista las temporary sin review_after asignado.",
+		"also list temporary entries without review_after (printed under a separate heading)": "también lista entradas temporary sin review_after (sección aparte en la salida)",
+		"always exit 0, even if there are overdue entries (informational mode)":               "siempre exit 0, incluso si hay entradas vencidas (modo solo-informativo)",
+		"✓ No overdue temporary entries.":                                                     "✓ No hay entradas temporales vencidas.",
+		"⚠ %d overdue temporary entry(ies):\n\n":                                              "⚠ %d entrada(s) temporal(es) vencida(s):\n\n",
+		"✓ No overdue entries.":                                                               "✓ No hay entradas vencidas.",
+		"\n%d temporary entry(ies) without review_after:\n\n":                                 "\n%d entrada(s) temporal(es) sin review_after:\n\n",
+		"    review_after: %s (overdue by %s)\n":                                              "    review_after: %s (vencido hace %s)\n",
+
+		// promote
+		"Change the status of an existing entry": "Cambia el status de una entrada existente",
+		"Updates the status: of the entry with the given id (active|temporary|deprecated). Designed as the wrap-up flow after `brain review`: once you no longer need a temporary entry, promote it to active (it became permanent) or deprecated (no longer applies). Optionally also updates review_after in the same call, or removes it with --clear-review-after.": "Actualiza el status: de la entrada con el id dado (active|temporary|deprecated). Pensado como flujo de cierre tras `brain review`: cuando ya no necesitás una entrada temporary, la promovés a active (se volvió definitiva) o deprecated (ya no aplica). Opcionalmente también actualiza review_after en la misma llamada, o lo elimina con --clear-review-after.",
+		"new status: active|temporary|deprecated (required)":          "nuevo status: active|temporary|deprecated (requerido)",
+		"also update review_after to this YYYY-MM-DD date (optional)": "actualizar también review_after a esta fecha YYYY-MM-DD (opcional)",
+		"remove review_after (incompatible with --review-after)":      "eliminar review_after (incompatible con --review-after)",
+
+		// bump
+		"Extend the review_after of an existing entry": "Extiende review_after de una entrada existente",
+		"Updates review_after of the entry with the given id, without touching status. Useful after `brain review` when a temporary entry is still valid and you want to extend its review deadline. For status changes use `promote`.": "Actualiza review_after de la entrada con el id dado, sin tocar status. Útil tras `brain review` cuando una entrada temporary sigue siendo válida y querés extender su plazo de revisión. Para cambios de status usá `promote`.",
+		"new YYYY-MM-DD date for review_after (required)": "nueva fecha YYYY-MM-DD para review_after (requerido)",
+
+		// doBrainUpdate
+		"✓ %s updated (%s)\n": "✓ %s actualizada (%s)\n",
+
+		// save
+		"Save an entry into the Brain's memories": "Guardar una entrada en las memorias del Brain",
+		"Appends a structured entry to the matching memory file. Requires the Brain to be initialized in the project (run `mobiai brain init` first).": "Añade una entrada estructurada al archivo de memoria correspondiente. Requiere que el Brain esté inicializado en el proyecto (corré `mobiai brain init` primero).",
+		"Save an architecture decision":                          "Guardar una decisión de arquitectura",
+		"Save a bugfix or workaround":                            "Guardar un bugfix o workaround",
+		"Save a reusable testing pattern":                        "Guardar un patrón de testing reusable",
+		"short entry title (required)":                           "título corto de la entrada (requerido)",
+		"android|ios|shared|kmp|flutter|react-native (optional)": "android|ios|shared|kmp|flutter|react-native (opcional)",
+		"project area (free-form, optional)":                     "área del proyecto (libre, opcional)",
+		"active|temporary|deprecated":                            "active|temporary|deprecated",
+		"YYYY-MM-DD date to review (optional)":                   "fecha YYYY-MM-DD para revisar (opcional)",
+		"Markdown body (if omitted, read from stdin)":            "cuerpo Markdown (si se omite, se lee de stdin)",
+		"related files, comma-separated (optional)":              "archivos relacionados, separados por coma (opcional)",
+		"✓ saved to %s\n  id: %s\n":                              "✓ guardado en %s\n  id: %s\n",
+
+		// mcp
+		"Start an MCP server that exposes the Brain as tools": "Arranca un servidor MCP que expone el Brain como tools",
+		"Starts an MCP (Model Context Protocol) server that exposes the Brain's operations (context, search, scan, save) as tools the agent can invoke directly. Communicates over stdio — designed for an MCP client (Claude Code, Cursor, Copilot CLI, etc.) to launch it as a subprocess. See brain/MCP-SETUP.md.": "Arranca un servidor MCP (Model Context Protocol) que expone las operaciones del Brain (context, search, scan, save) como tools que el agente puede invocar directamente. Comunica por stdio — pensado para que un cliente MCP (Claude Code, Cursor, Copilot CLI, etc.) lo lance como subproceso. Ver brain/MCP-SETUP.md.",
+
+		// install-mcp
+		"Register the Brain MCP server in AI clients (Claude Code, Cursor)": "Registra el server MCP de Brain en clientes IA (Claude Code, Cursor)",
+		"Adds the `mobiai-brain` server to each supported AI client's config, preserving the rest of the file. By default detects which clients are present (presence of ~/.claude or ~/.cursor); use --client to force a single one. Idempotent: re-running it with the same config is a no-op. Use --dry-run to preview without touching files, or --uninstall to remove the registration.": "Añade el server `mobiai-brain` al config de cada cliente IA soportado, preservando el resto del archivo. Por defecto detecta los clientes presentes (presencia de ~/.claude o ~/.cursor); con --client podés forzar uno solo. Idempotente: re-correrlo con la misma config no hace nada. Usá --dry-run para previsualizar sin tocar archivos, o --uninstall para quitar el registro.",
+		"clients to register: claude|cursor (repeatable or comma-separated; default: all detected)": "clientes a registrar: claude|cursor (repetible o coma-separado; default: todos los detectados)",
+		"show which files would be touched without writing anything":                                "muestra qué archivos se tocarían sin escribir nada",
+		"remove the registration instead of creating it":                                            "elimina el registro en lugar de crearlo",
+		"path to the mobiai binary to register (default: the binary in use)":                        "ruta al binario mobiai a registrar (default: el binario en uso)",
+
+		// printInstallResults
+		"Done. Restart the client for changes to take effect.": "Listo. Reiniciá el cliente para que tome efecto.",
+		"Done. Restart the client so it loads the MCP server.": "Listo. Reiniciá el cliente para que cargue el server MCP.",
+	})
+}

--- a/cli/internal/i18n/catalog_es.go
+++ b/cli/internal/i18n/catalog_es.go
@@ -31,9 +31,11 @@ var catalogES = map[string]string{
 	"mobiai binary %s → %s: downloading %s...\n": "binario mobiai %s → %s: descargando %s...\n",
 
 	// ── internal/cmd/lang.go ─────────────────────────────────────────────
-	"Show or set the CLI language (en/es)": "Mostrar o cambiar el idioma del CLI (en/es)",
-	"Current language: %s\n":               "Idioma actual: %s\n",
-	"Language set to %s.\n":                "Idioma cambiado a %s.\n",
+	"Show or set the CLI language (en/es)":                   "Mostrar o cambiar el idioma del CLI (en/es)",
+	"Current language: %s\n":                                 "Idioma actual:    %s\n",
+	"Available:        %s\n":                                 "Disponibles:      %s\n",
+	"Change it with `mobiai lang en` or `mobiai lang es`.\n": "Cambialo con `mobiai lang en` o `mobiai lang es`.\n",
+	"Language set to %s.\n":                                  "Idioma cambiado a %s.\n",
 }
 
 // intentionallyEnglish lists wrapped strings that have no Spanish translation on

--- a/cli/internal/i18n/catalog_es.go
+++ b/cli/internal/i18n/catalog_es.go
@@ -1,0 +1,53 @@
+package i18n
+
+// catalogES maps English source strings (the T() keys, taken verbatim from the
+// call sites) to their Spanish translations. Keys MUST be byte-identical to the
+// i18n.T("...") arguments in the code — TestCatalogCompleteness enforces that
+// every wrapped string has an entry here (or sits on intentionallyEnglish), and
+// TestCatalogVerbParity enforces that the %-verbs match between en and es.
+//
+// English strings absent from this map fall back to English at runtime.
+var catalogES = map[string]string{
+	// ── internal/cmd/update.go ───────────────────────────────────────────
+	"Refresh the catalog from the remote (or a local path with --catalog-root)":               "Refrescar el catálogo desde el remoto (o un local con --catalog-root)",
+	"Skills catalog updated to v%s.\n":                                                        "Catálogo de skills actualizado a v%s.\n",
+	"%d packs available at %s.\n":                                                             "%d packs disponibles en %s.\n",
+	"mobiai binary: %s (--skip-binary, did not check for an update).\n":                       "binario mobiai: %s (--skip-binary, no se verificó si hay update).\n",
+	"Warning: the catalog was updated, but the binary could not be updated: %v\n":             "Aviso: el catálogo se actualizó, pero no pude actualizar el binario: %v\n",
+	"Retry `mobiai update` later, or reinstall with the install script: https://mobiai.dev\n": "Reintentá `mobiai update` más tarde, o reinstalá con el install script: https://mobiai.dev\n",
+	"path to a local catalog (override)":                                                      "ruta a un catálogo local (override)",
+	"if the cache dir exists but is not a git repo, delete it and re-clone":                   "si el directorio cache existe sin ser un repo git, borralo y cloná de nuevo",
+	"only query GitHub releases and cache the result (does not touch the catalog)":            "solo consultar GitHub releases y cachear el resultado (no toca el catálogo)",
+	"print nothing on exit (intended for running from a background hook)":                     "no imprime nada al salir (pensado para correr desde un hook en background)",
+	"do not update the mobiai binary, only refresh the catalog":                               "no actualizar el binario mobiai, solo refrescar el catálogo",
+
+	// ── internal/cmd/updatecheck.go ──────────────────────────────────────
+	"MobiAI %s → %s available. Run: mobiai update\n":  "MobiAI %s → %s disponible. Actualizá con: mobiai update\n",
+	"MobiAI %s is up to date (latest release: %s).\n": "MobiAI %s está al día (último release: %s).\n",
+
+	// ── internal/cmd/selfupdate.go ───────────────────────────────────────
+	"mobiai binary updated to %s. Restart your terminal (or re-run mobiai) to use the new version.\n": "binario mobiai actualizado a %s. Reiniciá la terminal (o volvé a correr mobiai) para usar la nueva versión.\n",
+	"mobiai binary %s: up to date.\n":            "binario mobiai %s: al día.\n",
+	"mobiai binary %s → %s: downloading %s...\n": "binario mobiai %s → %s: descargando %s...\n",
+
+	// ── internal/cmd/lang.go ─────────────────────────────────────────────
+	"Show or set the CLI language (en/es)": "Mostrar o cambiar el idioma del CLI (en/es)",
+	"Current language: %s\n":               "Idioma actual: %s\n",
+	"Language set to %s.\n":                "Idioma cambiado a %s.\n",
+}
+
+// intentionallyEnglish lists wrapped strings that have no Spanish translation on
+// purpose (e.g. brand names, identifiers). Entries here satisfy
+// TestCatalogCompleteness without a catalogES mapping. Empty for now.
+var intentionallyEnglish = map[string]bool{}
+
+// registerES merges additional en→es pairs into catalogES. It lets each command
+// keep its translations in its own catalog_<cmd>_es.go file (registered from an
+// init func) instead of one giant map. Package-var initialization runs before
+// any init func, so the base catalogES literal above is always populated first;
+// last writer wins on duplicate keys.
+func registerES(m map[string]string) {
+	for k, v := range m {
+		catalogES[k] = v
+	}
+}

--- a/cli/internal/i18n/catalog_graph_es.go
+++ b/cli/internal/i18n/catalog_graph_es.go
@@ -1,0 +1,32 @@
+package i18n
+
+func init() {
+	registerES(map[string]string{
+		// ── internal/cmd/graph.go ────────────────────────────────────────────
+		"Semantic exploration of mobile code": "Exploración semántica del código mobile",
+		"MobiAI Graph indexes the project and lets you search symbols, find references, and get relevant context for a task. Lives at <repo>/.mobiai/graph/.": "MobiAI Graph indexa el proyecto y permite buscar símbolos, encontrar referencias y obtener contexto relevante para una tarea. Vive en <repo>/.mobiai/graph/.",
+		"project path (default: cwd)":                         "ruta del proyecto (default: cwd)",
+		"Index the project and save .mobiai/graph/index.json": "Indexa el proyecto y guarda .mobiai/graph/index.json",
+		"✓ Index generated: %s\n":                             "✓ Índice generado: %s\n",
+		"  Files:   %d\n":                                     "  Archivos: %d\n",
+		"  Symbols: %d\n":                                     "  Símbolos: %d\n",
+		"  Kotlin:  %d\n":                                     "  Kotlin: %d\n",
+		"  Swift:   %d\n":                                     "  Swift: %d\n",
+		"Show info about the current index":                   "Muestra info del índice actual",
+		"Index:     %s\n":                                     "Índice: %s\n",
+		"Generated: %s (%s)\n":                                "Generado: %s (%s)\n",
+		"Files:     %d\n":                                     "Archivos: %d\n",
+		"Symbols:   %d\n":                                     "Símbolos: %d\n",
+		"Kotlin:    %d\n":                                     "Kotlin: %d\n",
+		"Swift:     %d\n":                                     "Swift: %d\n",
+		"Search symbols by name":                              "Busca símbolos por nombre",
+		"max results to show (0 = no limit)":                  "máximo de resultados a mostrar (0 = sin límite)",
+		"filter by symbol kind (class, fun, object, interface, struct, enum, protocol, actor, func, extension)": "filtrar por tipo de símbolo (class, fun, object, interface, struct, enum, protocol, actor, func, extension)",
+		"No matches.": "Sin coincidencias.",
+		"… (showing %d, use --limit 0 to see all)\n": "… (mostrando %d, usá --limit 0 para ver todos)\n",
+		"List textual references to the symbol":      "Lista referencias textuales del símbolo",
+		"No references.":                             "Sin referencias.",
+		"Relevant files for a task (heuristic)":      "Archivos relevantes para una tarea (heurística)",
+		"No relevant files found.":                   "Sin archivos relevantes encontrados.",
+	})
+}

--- a/cli/internal/i18n/catalog_helpers_es.go
+++ b/cli/internal/i18n/catalog_helpers_es.go
@@ -1,0 +1,34 @@
+package i18n
+
+// Translations for helper functions that return user-facing fragments embedded
+// in larger lines (relative-time, overdue labels, install-action labels, scan
+// summary). These are kept here because they were left unwrapped by the
+// per-command localization pass (they are return values / closures, not direct
+// print sites) and would otherwise leak English into Spanish output.
+func init() {
+	registerES(map[string]string{
+		// ── internal/cmd/graph.go: humanizeAge ───────────────────────────
+		"%dm ago": "hace %dm",
+		"%dh ago": "hace %dh",
+		"%dd ago": "hace %dd",
+
+		// ── internal/cmd/brain.go: daysOverdueLabel ──────────────────────
+		"today":   "hoy",
+		"1 day":   "1 día",
+		"%d days": "%d días",
+
+		// ── internal/cmd/brain.go: installIconAndLabel ───────────────────
+		"registered":                     "registrado",
+		"updated":                        "actualizado",
+		"unchanged (already registered)": "sin cambios (ya estaba registrado)",
+		"removed":                        "eliminado",
+		"was not registered":             "no estaba registrado",
+		"skipped (client not installed)": "saltado (cliente no instalado)",
+
+		// ── internal/cmd/brain.go: printScanSummary ──────────────────────
+		"\nSummary:\n":        "\nResumen:\n",
+		"  Type:        %s\n": "  Tipo:        %s\n",
+		"  Platforms:   %s\n": "  Plataformas: %s\n",
+		"  Warnings:    %d\n": "  Advertencias: %d\n",
+	})
+}

--- a/cli/internal/i18n/catalog_main_es.go
+++ b/cli/internal/i18n/catalog_main_es.go
@@ -1,0 +1,37 @@
+package i18n
+
+func init() {
+	registerES(map[string]string{
+		// ── cmd/mobiai/main.go: usage template headings ──────────────────
+		"Usage:":                                "Uso:",
+		"[command]":                             "[comando]",
+		"Aliases:":                              "Alias:",
+		"Examples:":                             "Ejemplos:",
+		"Available commands:":                   "Comandos disponibles:",
+		"Global flags:":                         "Flags globales:",
+		"Additional topics:":                    "Temas adicionales:",
+		"Use ":                                  "Usá ",
+		"for more information about a command.": "para más información sobre un comando.",
+
+		// ── cmd/mobiai/main.go: root + help command ──────────────────────
+		"MobiAI CLI — manage the MobiAI ecosystem for AI-assisted mobile development": "MobiAI CLI — gestiona el ecosistema MobiAI para desarrollo móvil con IA",
+		"MobiAI CLI is the unified tool of the MobiAI ecosystem: skills, agents, MCPs, and orchestration across clients for AI-assisted mobile development. Today it manages skills compatible with the agentskills.io standard on any supported client; agents and MCP servers are coming soon.": "MobiAI CLI es la herramienta unificada del ecosistema MobiAI: skills, agentes, MCPs y orquestación entre clientes para desarrollo móvil asistido por IA. Hoy gestiona skills compatibles con el standard agentskills.io en cualquier cliente compatible; próximamente sumará agentes y servidores MCP.",
+		"Help about any command":         "Ayuda sobre cualquier comando",
+		"Help about any mobiai command.": "Ayuda sobre cualquier comando de mobiai.",
+		"Unknown command %q\n":           "Comando desconocido %q\n",
+		"help for %s":                    "ayuda de %s",
+		"mobiai version":                 "versión de mobiai",
+
+		// ── internal/cmd/flags.go: global persistent flags ───────────────
+		"force specific adapters (default: all detected)":               "fuerza adapters específicos (default: todos los detectados)",
+		"assume yes on confirmations (CI-friendly)":                     "asume sí en confirmaciones (CI-friendly)",
+		"more output (currently only affects 'mobiai update')":          "más output (hoy sólo afecta a 'mobiai update')",
+		"disable ANSI colors in help output":                            "deshabilita colores ANSI en el help",
+		"path to a local catalog (overrides ~/.mobiai/cache/catalog)":   "ruta a un catálogo local (override de ~/.mobiai/cache/catalog)",
+		"include tier-3 adapters (speculative paths) in auto-detection": "incluir adapters tier-3 (paths especulativos) en la auto-detección",
+
+		// ── internal/cmd/update.go: syncRemoteCatalog prints ─────────────
+		"Syncing catalog (git pull)...\n": "Sincronizando catálogo (git pull)...\n",
+		"Cloning catalog from %s...\n":    "Clonando catálogo desde %s...\n",
+	})
+}

--- a/cli/internal/i18n/catalog_misc_es.go
+++ b/cli/internal/i18n/catalog_misc_es.go
@@ -1,0 +1,44 @@
+package i18n
+
+// catalog_misc_es.go holds the Spanish translations for the misc command set:
+// internal/cmd/doctor.go, catalog.go, hosts.go and status.go. Keys are
+// byte-identical to the i18n.T("...") arguments at those call sites.
+func init() {
+	registerES(map[string]string{
+		// ── internal/cmd/doctor.go ───────────────────────────────────────────
+		"Thorough diagnostics for CLI, hosts and catalog": "Diagnóstico exhaustivo del CLI, hosts y catálogo",
+		"MobiAI %s — diagnostics\n\n":                     "MobiAI %s — diagnóstico\n\n",
+		"Supported hosts:":                                "Hosts soportados:",
+		"Catalog:":                                        "Catálogo:",
+		"  (never synced)":                                "  (nunca se sincronizó)",
+		"  Last sync: %s\n":                               "  Última sincronización: %s\n",
+		"  Version:   %s\n":                               "  Versión: %s\n",
+		"Drift check:":                                    "Chequeo de drift:",
+		"  ✓ no drift detected (Verify is a stub in this version)": "  ✓ sin drift detectado (Verify es stub en esta versión)",
+
+		// ── internal/cmd/catalog.go ──────────────────────────────────────────
+		"Inspect the catalog (debug)": "Inspeccionar el catálogo (debug)",
+		"Hidden subcommand for catalog/resolver smoke tests. Not intended for end users.": "Subcomando oculto para smoke tests del catálogo/resolver. No es para usuarios finales.",
+		"Path to the catalog root (directory containing .claude-plugin/marketplace.json)": "Ruta a la raíz del catálogo (el directorio que contiene .claude-plugin/marketplace.json)",
+		"List the packs in the catalog": "Lista los packs del catálogo",
+		"Catalog: %s (version %s)\n":    "Catálogo: %s (versión %s)\n",
+		"none":                          "ninguna",
+		"Resolve the install order for the given packs": "Resuelve el orden de instalación para los packs dados",
+		"Install order:\n": "Orden de instalación:\n",
+
+		// ── internal/cmd/hosts.go ────────────────────────────────────────────
+		"Inspect supported hosts (debug)":                                               "Inspeccionar los hosts soportados (debug)",
+		"Hidden subcommand for hosts-registry smoke tests. Not intended for end users.": "Subcomando oculto para smoke tests del registry de hosts. No es para usuarios finales.",
+		"List supported hosts and which are detected":                                   "Lista los hosts soportados y cuáles están detectados",
+		"Supported hosts (%d adapters loaded):\n":                                       "Hosts soportados (%d adapters cargados):\n",
+
+		// ── shared: doctor.go + hosts.go ─────────────────────────────────────
+		"not detected": "no detectado",
+
+		// ── internal/cmd/status.go ───────────────────────────────────────────
+		"Summary of detected hosts, installed packs and catalog state":                                                    "Resumen de hosts detectados, packs instalados y estado del catálogo",
+		"  (none detected — install Claude Code, Cursor, Gemini CLI, Codex, or another agentskills.io-compatible client)": "  (ninguno detectado — instalá Claude Code, Cursor, Gemini CLI, Codex u otro cliente compatible con agentskills.io)",
+		"Installed packs:": "Packs instalados:",
+		"  (none)":         "  (ninguno)",
+	})
+}

--- a/cli/internal/i18n/catalog_skills_es.go
+++ b/cli/internal/i18n/catalog_skills_es.go
@@ -1,0 +1,22 @@
+package i18n
+
+// catalog_skills_es registers the Spanish translations for internal/cmd/skills.go.
+// Keys MUST be byte-identical to the i18n.T("...") arguments at the call sites.
+func init() {
+	registerES(map[string]string{
+		"Manage MobiAI skills":                            "Gestionar skills de MobiAI",
+		"force specific adapters (default: all detected)": "fuerza adapters específicos (default: todos los detectados)",
+		"assume yes on confirmations":                     "asume sí en confirmaciones",
+		"path to a local catalog":                         "ruta a un catálogo local",
+		"Install packs into detected hosts":               "Instalar packs en los hosts detectados",
+		"Uninstall packs from detected hosts":             "Desinstalar packs de los hosts detectados",
+		"List installed packs":                            "Listar packs instalados",
+		"No packs installed.":                             "No hay packs instalados.",
+		"Interactive picker to install/uninstall skills":  "Selector interactivo para instalar/desinstalar skills",
+		"Launches the TUI picker to choose skill packs and apply changes to detected clients (Claude Code, Cursor, Codex, etc).": "Lanza el picker TUI para elegir packs de skills y aplicar los cambios sobre los clientes detectados (Claude Code, Cursor, Codex, etc).",
+		"Cancelled.":        "Cancelado.",
+		"Done.":             "Listo.",
+		"Install plan:":     "Plan de instalación:",
+		"Continue? [y/N]: ": "¿Continuar? [y/N]: ",
+	})
+}

--- a/cli/internal/i18n/catalog_tui_es.go
+++ b/cli/internal/i18n/catalog_tui_es.go
@@ -1,0 +1,23 @@
+package i18n
+
+func init() {
+	registerES(map[string]string{
+		// ── internal/tui/tui.go ──────────────────────────────────────────────
+		"No AI client detected.\nInstall Claude Code, Cursor, Gemini CLI or Codex and run `mobiai` again.\n": "No detecté ningún cliente de IA.\nInstalá Claude Code, Cursor, Gemini CLI o Codex y volvé a correr `mobiai`.\n",
+
+		// ── internal/tui/view.go ─────────────────────────────────────────────
+		"Detected hosts (%d): %s": "Hosts detectados (%d): %s",
+		"↑↓ navigate  [space] change action  [enter] apply  [q] quit": "↑↓ navegar  [espacio] cambiar acción  [enter] aplicar  [q] salir",
+		"Confirm changes":                               "Confirmar cambios",
+		"No pending changes.\n":                         "No hay cambios pendientes.\n",
+		"To install:\n":                                 "A instalar:\n",
+		"To uninstall:\n":                               "A desinstalar:\n",
+		"\nOn %d detected hosts.\n\n":                   "\nEn %d hosts detectados.\n\n",
+		"[y] confirm  [n] back to picker  [esc] cancel": "[y] confirmar  [n] volver al picker  [esc] cancelar",
+		"Applying changes... %d/%d":                     "Aplicando cambios... %d/%d",
+		"✓ Done":                                        "✓ Listo",
+		"⚠ Finished with %d errors\n\n":                 "⚠ Terminado con %d errores\n\n",
+		"\n⚠ Could not save installed.json: %v\n":       "\n⚠ No pude guardar installed.json: %v\n",
+		"\n[enter] close":                               "\n[enter] cerrar",
+	})
+}

--- a/cli/internal/i18n/i18n.go
+++ b/cli/internal/i18n/i18n.go
@@ -1,0 +1,100 @@
+// Package i18n provides minimal gettext-style localization for the CLI.
+//
+// The English source string IS the catalog key. T("...") returns the Spanish
+// translation when the active language is ES and a translation exists;
+// otherwise it returns the English source (the fallback). For Printf-style
+// calls, wrap the FORMAT string — the format verbs are preserved by the
+// translation (enforced by TestCatalogVerbParity).
+//
+// Localization boundary (what gets wrapped in T): command output, cobra
+// Short/Long/Use, flag usages, and usage-template headings. Go error strings
+// (fmt.Errorf, %w-wrapped) are intentionally left in English and are NOT
+// wrapped in T — translating partial error chains is out of scope.
+package i18n
+
+import (
+	"os"
+	"sync"
+)
+
+// Lang is a supported CLI language code.
+type Lang string
+
+const (
+	EN Lang = "en"
+	ES Lang = "es"
+)
+
+var (
+	mu      sync.RWMutex
+	current = EN
+)
+
+// Supported returns the languages the CLI can switch between, in display order.
+func Supported() []Lang { return []Lang{EN, ES} }
+
+// Parse maps a string to a supported Lang, reporting whether it was valid.
+func Parse(s string) (Lang, bool) {
+	switch Lang(s) {
+	case EN:
+		return EN, true
+	case ES:
+		return ES, true
+	default:
+		return EN, false
+	}
+}
+
+// Current returns the active language.
+func Current() Lang {
+	mu.RLock()
+	defer mu.RUnlock()
+	return current
+}
+
+// SetLang sets the active language for this process. It does NOT persist the
+// choice — use internal/state.Config for that.
+func SetLang(l Lang) {
+	mu.Lock()
+	current = l
+	mu.Unlock()
+}
+
+// Init resolves the active language and sets it for this process. Precedence:
+//
+//	MOBIAI_LANG env (one-off override) > persisted preference > EN default.
+//
+// persisted is the saved preference (e.g. state.Config.Lang); pass "" if none.
+// Unrecognized values are ignored (fall through to the next source). English
+// is the default — Spanish is an explicit opt-in, never auto-detected from the
+// OS locale.
+func Init(persisted string) {
+	lang := EN
+	if l, ok := Parse(persisted); ok {
+		lang = l
+	}
+	if env := os.Getenv("MOBIAI_LANG"); env != "" {
+		if l, ok := Parse(env); ok {
+			lang = l
+		}
+	}
+	SetLang(lang)
+}
+
+// T translates an English source string to the active language (gettext model).
+// Returns the English source unchanged when the active language is EN or when
+// no translation exists for the current language.
+func T(en string) string {
+	mu.RLock()
+	cur := current
+	mu.RUnlock()
+	if cur == EN {
+		return en
+	}
+	// catalogES is built once at package init and never mutated, so it is
+	// safe to read without holding the lock.
+	if s, ok := catalogES[en]; ok {
+		return s
+	}
+	return en
+}

--- a/cli/internal/i18n/i18n_guard_test.go
+++ b/cli/internal/i18n/i18n_guard_test.go
@@ -1,0 +1,213 @@
+package i18n
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestNoUntranslatedUserStrings is the reverse of TestCatalogCompleteness: that
+// test proves every wrapped string HAS a translation; this one proves every
+// user-facing string IS wrapped. Together they make "mobiai lang es" trustworthy
+// and fail CI when someone adds a new CLI string without localizing it.
+//
+// It statically scans the user-facing packages (cmd, tui, main) for:
+//   - cobra Short/Long values that are raw string literals (must be i18n.T(...))
+//   - flag usage descriptions that are raw string literals (must be i18n.T(...))
+//   - prose strings printed to the user (fmt.Fprint*/Print*, cmd.Print*) that
+//     are not wrapped
+//
+// It deliberately does NOT scan internal/brain, internal/graph, internal/host,
+// or skills: error messages, MCP tool descriptions and skill content stay in
+// English by design.
+//
+// An intentional exception (a symbol, layout string, or identifier that is the
+// same in every language) goes in guardAllow below — a visible, reviewable
+// opt-out rather than a silent gap.
+func TestNoUntranslatedUserStrings(t *testing.T) {
+	// User-facing packages, relative to internal/i18n.
+	dirs := []string{
+		filepath.Join("..", "cmd"),
+		filepath.Join("..", "tui"),
+		filepath.Join("..", "..", "cmd", "mobiai"),
+	}
+
+	var violations []string
+	fset := token.NewFileSet()
+
+	for _, dir := range dirs {
+		pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
+			return !strings.HasSuffix(fi.Name(), "_test.go")
+		}, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", dir, err)
+		}
+		for _, pkg := range pkgs {
+			for _, file := range pkg.Files {
+				ast.Inspect(file, func(n ast.Node) bool {
+					switch node := n.(type) {
+					case *ast.KeyValueExpr:
+						checkShortLong(t, fset, node, &violations)
+					case *ast.CallExpr:
+						checkFlagUsage(fset, node, &violations)
+						checkPrint(fset, node, &violations)
+					}
+					return true
+				})
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("%d user-facing string(s) are not localized.\n"+
+			"Wrap each with i18n.T(\"...\") so `mobiai lang es` can translate it (then add the\n"+
+			"Spanish to a catalog_*_es.go). If a string is intentionally English (a symbol,\n"+
+			"layout, or identifier — NOT skill/MCP content, which is English by design), add it\n"+
+			"to guardAllow in i18n_guard_test.go.\n\n  %s",
+			len(violations), strings.Join(violations, "\n  "))
+	}
+}
+
+// checkShortLong flags cobra Short:/Long: values that aren't i18n.T(...) calls.
+func checkShortLong(t *testing.T, fset *token.FileSet, kv *ast.KeyValueExpr, out *[]string) {
+	key, ok := kv.Key.(*ast.Ident)
+	if !ok || (key.Name != "Short" && key.Name != "Long") {
+		return
+	}
+	if litStr, ok := stringLiteralOf(kv.Value); ok {
+		if !guardAllow[litStr] {
+			*out = append(*out, fmt.Sprintf("%s: cobra %s: %q", fset.Position(kv.Pos()), key.Name, litStr))
+		}
+	}
+}
+
+// flagSetters are the pflag methods whose LAST argument is a usage string.
+var flagSetters = map[string]bool{
+	"String": true, "StringP": true, "StringArray": true, "StringArrayP": true,
+	"StringSlice": true, "StringSliceP": true, "Bool": true, "BoolP": true,
+	"Int": true, "IntP": true, "Int64": true, "Duration": true, "Float64": true,
+}
+
+func checkFlagUsage(fset *token.FileSet, ce *ast.CallExpr, out *[]string) {
+	sel, ok := ce.Fun.(*ast.SelectorExpr)
+	if !ok || !flagSetters[sel.Sel.Name] || len(ce.Args) == 0 {
+		return
+	}
+	last := ce.Args[len(ce.Args)-1]
+	if litStr, ok := stringLiteralOf(last); ok {
+		if !guardAllow[litStr] {
+			*out = append(*out, fmt.Sprintf("%s: flag usage: %q", fset.Position(last.Pos()), litStr))
+		}
+	}
+}
+
+// printFuncs are output funcs whose format/string arg should be localized.
+var printFuncs = map[string]bool{
+	"Fprintf": true, "Fprintln": true, "Fprint": true,
+	"Printf": true, "Println": true, "Print": true,
+}
+
+func checkPrint(fset *token.FileSet, ce *ast.CallExpr, out *[]string) {
+	sel, ok := ce.Fun.(*ast.SelectorExpr)
+	if !ok || !printFuncs[sel.Sel.Name] {
+		return
+	}
+	// For fmt.Fprint*, the writer is arg 0 and the format/string is arg 1.
+	// For Print*/cmd.Print*, the format/string is arg 0.
+	idx := 0
+	if strings.HasPrefix(sel.Sel.Name, "Fprint") {
+		idx = 1
+	}
+	if len(ce.Args) <= idx {
+		return
+	}
+	litStr, ok := stringLiteralOf(ce.Args[idx])
+	if !ok {
+		return // already wrapped (i18n.T) or a variable — fine
+	}
+	if guardAllow[litStr] || !isProse(litStr) {
+		return // symbol/layout/format-only, or an explicit exception
+	}
+	*out = append(*out, fmt.Sprintf("%s: printed string: %q", fset.Position(ce.Args[idx].Pos()), litStr))
+}
+
+// stringLiteralOf returns the unquoted value when expr is a bare string literal
+// or a concatenation of string literals (`"a" + "b"`). It returns ok=false for
+// anything else (e.g. an i18n.T(...) call or a variable), which is treated as
+// "not a raw user-facing literal".
+func stringLiteralOf(expr ast.Expr) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return "", false
+		}
+		s, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return "", false
+		}
+		return s, true
+	case *ast.BinaryExpr:
+		if e.Op != token.ADD {
+			return "", false
+		}
+		l, lok := stringLiteralOf(e.X)
+		r, rok := stringLiteralOf(e.Y)
+		if lok && rok {
+			return l + r, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// verbStripper removes Go format verbs so isProse only sees real words.
+var verbStripper = regexp.MustCompile(`%[#+\- 0-9.*]*[a-zA-Z]`)
+
+// proseWord matches a run of 4+ letters — enough to call a string "prose"
+// rather than a symbol/layout/identifier fragment.
+var proseWord = regexp.MustCompile(`\p{L}{4,}`)
+
+// isProse reports whether s reads as natural language (and so should be
+// localized) rather than pure layout/symbols (e.g. "%-13s │ %s\n", "✓ %s\n").
+func isProse(s string) bool {
+	return proseWord.MatchString(verbStripper.ReplaceAllString(s, ""))
+}
+
+// guardAllow lists user-facing-position string literals that are intentionally
+// left English: layout/table glue, tech-category labels, and identifiers that
+// are identical in every language. Each entry is a deliberate, reviewable
+// opt-out from localization. Skill/MCP content is NOT here — those packages are
+// not scanned at all.
+var guardAllow = map[string]bool{
+	// Memory-schema field labels — these mirror the YAML frontmatter keys of a
+	// memory entry (identifiers, not prose). brain.go review/overdue/promote.
+	"    platform: %s\n":        true,
+	"    area: %s\n":            true,
+	"  status: %s → %s\n":       true,
+	"  review_after: %s → %s\n": true,
+
+	// Domain terms kept English across the whole product (pack/host are used
+	// untranslated everywhere, like "skills"). Headers in catalog/skills/status.
+	"Packs (%d):\n":         true,
+	"Pack          | Hosts": true,
+	"  Packs (%d): %s\n":    true,
+	"  Hosts (%d): %s\n":    true,
+	"Hosts:":                true,
+
+	// Pure layout / technical annotation (no translatable prose).
+	"  - %-14s v%-8s deps: %s\n": true,
+	"%s  (score %d)\n":           true,
+
+	// Brand wordmark line (mobiai status header).
+	"MobiAI %s\n\n": true,
+
+	// Machine-readable JSON output — not UI prose. (mobiai skills, --json path)
+	"{\"name\":%q,\"source\":\"./skills/%s\",\"description\":\"\",\"category\":\"\"}": true,
+}

--- a/cli/internal/i18n/i18n_test.go
+++ b/cli/internal/i18n/i18n_test.go
@@ -1,0 +1,155 @@
+package i18n
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestT(t *testing.T) {
+	t.Cleanup(func() { SetLang(EN) })
+
+	SetLang(EN)
+	const key = "Skills catalog updated to v%s.\n"
+	if got := T(key); got != key {
+		t.Errorf("EN should return the source string; got %q", got)
+	}
+
+	SetLang(ES)
+	if got := T(key); got != "Catálogo de skills actualizado a v%s.\n" {
+		t.Errorf("ES translation wrong; got %q", got)
+	}
+	if got := T("a string with no translation"); got != "a string with no translation" {
+		t.Errorf("ES must fall back to the English source for unknown keys; got %q", got)
+	}
+}
+
+func TestInit_Precedence(t *testing.T) {
+	t.Cleanup(func() { SetLang(EN) })
+
+	t.Setenv("MOBIAI_LANG", "") // empty == unset for Init's purposes
+	Init("")
+	if Current() != EN {
+		t.Errorf("default should be EN; got %s", Current())
+	}
+	Init("es")
+	if Current() != ES {
+		t.Errorf("persisted preference should win; got %s", Current())
+	}
+	Init("garbage")
+	if Current() != EN {
+		t.Errorf("unrecognized persisted value should fall back to EN; got %s", Current())
+	}
+
+	t.Setenv("MOBIAI_LANG", "en")
+	Init("es")
+	if Current() != EN {
+		t.Errorf("MOBIAI_LANG should override the persisted preference; got %s", Current())
+	}
+}
+
+// verbRe matches Go fmt verbs (with optional flags/width/precision/arg-index).
+var verbRe = regexp.MustCompile(`%[#0\-+ '\[\]0-9.*]*[a-zA-Z%]`)
+
+// formatVerbs returns the ordered sequence of verb letters in s, skipping the
+// literal "%%". e.g. "got %d of %s" -> ["d","s"].
+func formatVerbs(s string) []string {
+	var out []string
+	for _, m := range verbRe.FindAllString(s, -1) {
+		if m == "%%" {
+			continue
+		}
+		out = append(out, m[len(m)-1:])
+	}
+	return out
+}
+
+// TestCatalogVerbParity guards against %!s(MISSING) / wrong-order bugs: every
+// (en, es) pair must have the identical ordered sequence of format verbs.
+func TestCatalogVerbParity(t *testing.T) {
+	for en, es := range catalogES {
+		ev, sv := formatVerbs(en), formatVerbs(es)
+		if !slices.Equal(ev, sv) {
+			t.Errorf("format-verb mismatch:\n  en %q -> %v\n  es %q -> %v", en, ev, es, sv)
+		}
+	}
+}
+
+// TestCatalogCompleteness is the safety net that makes English-as-key safe: it
+// statically scans every i18n.T("literal") call in the module and asserts each
+// has an es translation (or sits on intentionallyEnglish). Without it, a single
+// byte difference between a call site and its catalog key would silently leak
+// English in es mode with the build still green.
+func TestCatalogCompleteness(t *testing.T) {
+	moduleRoot := filepath.Join("..", "..") // internal/i18n -> cli/
+	fset := token.NewFileSet()
+	var missing []string
+
+	err := filepath.Walk(moduleRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case "embedded", ".git", "testdata", "dist":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return fmt.Errorf("parse %s: %w", path, perr)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			ce, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := ce.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "i18n" || sel.Sel.Name != "T" || len(ce.Args) == 0 {
+				return true
+			}
+			lit, ok := ce.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				t.Errorf("%s: i18n.T() must be called with a string literal (catalog keys are extracted statically)", fset.Position(ce.Pos()))
+				return true
+			}
+			key, uerr := strconv.Unquote(lit.Value)
+			if uerr != nil {
+				t.Errorf("%s: unquote %s: %v", fset.Position(ce.Pos()), lit.Value, uerr)
+				return true
+			}
+			if _, ok := catalogES[key]; ok {
+				return true
+			}
+			if intentionallyEnglish[key] {
+				return true
+			}
+			missing = append(missing, fmt.Sprintf("%s: %q", fset.Position(ce.Pos()), key))
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) > 0 {
+		t.Errorf("%d wrapped string(s) lack an es translation — add to catalogES or intentionallyEnglish:\n  %s",
+			len(missing), strings.Join(missing, "\n  "))
+	}
+}

--- a/cli/internal/state/config.go
+++ b/cli/internal/state/config.go
@@ -1,0 +1,62 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Config holds user preferences persisted at <home>/config.json.
+// Currently just the CLI language; extend with new fields as needed.
+type Config struct {
+	Lang string `json:"lang,omitempty"` // "en" | "es" (empty = default)
+}
+
+// LoadConfig reads config.json. Returns a zero-valued Config (no error) if the
+// file does not exist, so callers get default behavior on a fresh install.
+func LoadConfig(p Paths) (*Config, error) {
+	data, err := os.ReadFile(p.ConfigFile())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{}, nil
+		}
+		return nil, fmt.Errorf("read config.json: %w", err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse config.json: %w", err)
+	}
+	return &c, nil
+}
+
+// Save writes config.json atomically (temp file + rename), mirroring meta.go.
+func (c *Config) Save(p Paths) error {
+	if err := os.MkdirAll(p.Home, 0o755); err != nil {
+		return fmt.Errorf("mkdir home dir: %w", err)
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	final := p.ConfigFile()
+	tmp, err := os.CreateTemp(filepath.Dir(final), "config-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create tmp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, final); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename tmp to %s: %w", final, err)
+	}
+	return nil
+}

--- a/cli/internal/state/config_test.go
+++ b/cli/internal/state/config_test.go
@@ -1,0 +1,37 @@
+package state
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestConfig_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MOBIAI_HOME", filepath.Join(tmp, ".mobiai"))
+	p, err := NewPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Missing file -> zero-valued config, no error.
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("load missing config: %v", err)
+	}
+	if cfg.Lang != "" {
+		t.Errorf("fresh config should have empty Lang; got %q", cfg.Lang)
+	}
+
+	cfg.Lang = "es"
+	if err := cfg.Save(p); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Lang != "es" {
+		t.Errorf("Lang after round-trip: got %q, want es", got.Lang)
+	}
+}

--- a/cli/internal/state/paths.go
+++ b/cli/internal/state/paths.go
@@ -34,7 +34,7 @@ func (p Paths) State() string         { return filepath.Join(p.Home, "state") }
 func (p Paths) Logs() string          { return filepath.Join(p.Home, "logs") }
 func (p Paths) InstalledFile() string { return filepath.Join(p.State(), "installed.json") }
 func (p Paths) MetaFile() string      { return filepath.Join(p.Cache(), "meta.json") }
-func (p Paths) ConfigFile() string    { return filepath.Join(p.Home, "config.toml") }
+func (p Paths) ConfigFile() string    { return filepath.Join(p.Home, "config.json") }
 
 // EnsureDirs creates Bin, Cache, State, and Logs if they don't exist.
 // Permissions: 0o755.

--- a/cli/internal/tui/tui.go
+++ b/cli/internal/tui/tui.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/catalog"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/host"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/resolver"
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 )
@@ -391,7 +392,7 @@ func (m Model) toggleAt(i int) Model {
 func (m Model) View() string {
 	switch m.mode {
 	case ModeNoHosts:
-		return "No AI client detected.\nInstall Claude Code, Cursor, Gemini CLI or Codex and run `mobiai` again.\n"
+		return i18n.T("No AI client detected.\nInstall Claude Code, Cursor, Gemini CLI or Codex and run `mobiai` again.\n")
 	case ModePicker:
 		return m.viewPicker()
 	case ModeConfirm:

--- a/cli/internal/tui/view.go
+++ b/cli/internal/tui/view.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
 )
 
 var (
@@ -22,7 +24,7 @@ func (m Model) viewPicker() string {
 	for _, h := range m.hosts {
 		hostNames = append(hostNames, h.Name())
 	}
-	b.WriteString(titleStyle.Render("MobiAI") + "    " + dimStyle.Render(fmt.Sprintf("Detected hosts (%d): %s", len(m.hosts), strings.Join(hostNames, " · "))) + "\n\n")
+	b.WriteString(titleStyle.Render("MobiAI") + "    " + dimStyle.Render(fmt.Sprintf(i18n.T("Detected hosts (%d): %s"), len(m.hosts), strings.Join(hostNames, " · "))) + "\n\n")
 
 	rows := m.PackRows()
 	for i, r := range rows {
@@ -36,7 +38,7 @@ func (m Model) viewPicker() string {
 		b.WriteString(line + "\n")
 	}
 
-	b.WriteString("\n" + dimStyle.Render("↑↓ navigate  [space] change action  [enter] apply  [q] quit") + "\n")
+	b.WriteString("\n" + dimStyle.Render(i18n.T("↑↓ navigate  [space] change action  [enter] apply  [q] quit")) + "\n")
 	return b.String()
 }
 
@@ -72,7 +74,7 @@ func pickerMarker(r PackRow, totalHosts int) string {
 
 func (m Model) viewConfirm() string {
 	var b strings.Builder
-	b.WriteString(titleStyle.Render("Confirm changes") + "\n\n")
+	b.WriteString(titleStyle.Render(i18n.T("Confirm changes")) + "\n\n")
 
 	var installs, uninstalls []string
 	for name, act := range m.userActions {
@@ -87,10 +89,10 @@ func (m Model) viewConfirm() string {
 	sort.Strings(uninstalls)
 
 	if len(installs) == 0 && len(uninstalls) == 0 {
-		b.WriteString("No pending changes.\n")
+		b.WriteString(i18n.T("No pending changes.\n"))
 	}
 	if len(installs) > 0 {
-		b.WriteString("To install:\n")
+		b.WriteString(i18n.T("To install:\n"))
 		for _, name := range installs {
 			b.WriteString(checkboxStyle.Render("  + ") + name + "\n")
 		}
@@ -99,19 +101,19 @@ func (m Model) viewConfirm() string {
 		if len(installs) > 0 {
 			b.WriteString("\n")
 		}
-		b.WriteString("To uninstall:\n")
+		b.WriteString(i18n.T("To uninstall:\n"))
 		for _, name := range uninstalls {
 			b.WriteString(removalStyle.Render("  - ") + name + "\n")
 		}
 	}
-	b.WriteString(fmt.Sprintf("\nOn %d detected hosts.\n\n", len(m.hosts)))
-	b.WriteString(dimStyle.Render("[y] confirm  [n] back to picker  [esc] cancel"))
+	b.WriteString(fmt.Sprintf(i18n.T("\nOn %d detected hosts.\n\n"), len(m.hosts)))
+	b.WriteString(dimStyle.Render(i18n.T("[y] confirm  [n] back to picker  [esc] cancel")))
 	return b.String()
 }
 
 func (m Model) viewProgress() string {
 	var b strings.Builder
-	b.WriteString(titleStyle.Render(fmt.Sprintf("Applying changes... %d/%d", m.installDone, len(m.installPlan))) + "\n\n")
+	b.WriteString(titleStyle.Render(fmt.Sprintf(i18n.T("Applying changes... %d/%d"), m.installDone, len(m.installPlan))) + "\n\n")
 	for i, s := range m.installPlan {
 		marker := "  "
 		if i < m.installDone {
@@ -132,9 +134,9 @@ func (m Model) viewResult() string {
 	// usuario pierde la confirmación de qué se instaló. Re-renderizamos
 	// el plan completo con su marker final.
 	if len(m.installErrors) == 0 {
-		b.WriteString(checkboxStyle.Render("✓ Done") + "\n\n")
+		b.WriteString(checkboxStyle.Render(i18n.T("✓ Done")) + "\n\n")
 	} else {
-		b.WriteString(fmt.Sprintf("⚠ Finished with %d errors\n\n", len(m.installErrors)))
+		b.WriteString(fmt.Sprintf(i18n.T("⚠ Finished with %d errors\n\n"), len(m.installErrors)))
 	}
 
 	errBy := make(map[[2]string]error, len(m.installErrors))
@@ -150,8 +152,8 @@ func (m Model) viewResult() string {
 	}
 
 	if m.installSaveErr != nil {
-		b.WriteString(fmt.Sprintf("\n⚠ Could not save installed.json: %v\n", m.installSaveErr))
+		b.WriteString(fmt.Sprintf(i18n.T("\n⚠ Could not save installed.json: %v\n"), m.installSaveErr))
 	}
-	b.WriteString(dimStyle.Render("\n[enter] close"))
+	b.WriteString(dimStyle.Render(i18n.T("\n[enter] close")))
 	return b.String()
 }


### PR DESCRIPTION
## Summary
Adds `mobiai lang es|en`: a gettext-style localization layer that lets users switch the CLI's user-facing output between English (default) and Spanish.

## How it works
- English source strings are the catalog keys; `i18n.T("...")` returns the Spanish translation when the active language is `es`, else the English source (fallback). For Printf, the **format string** is wrapped.
- `mobiai lang [en|es]` shows or sets the language, persisted to `~/.mobiai/config.json`. Precedence: `MOBIAI_LANG` env > persisted preference > `en`.
- `i18n.Init()` runs in `main()` **before** the cobra tree is built, so help / Short / Long / flag-usages render in the active language too.

## Localization boundary
**Translated (human-facing):** command output, cobra Short/Long, flag usages (global + per-command), usage-template headings, the TUI selector, every subcommand's `--help` usage, and helper fragments (relative time, install-action labels, scan summary).
**Intentionally English:** errors (`fmt.Errorf`, `%w`-wrapped), MCP tool descriptions (consumed by AI agents, not the human), and internal/log strings. Spanish was recovered **verbatim** from the i18n commit `51dcef2`.

## Why each change
- `internal/i18n/` (new): the `T()`/`Init()` engine + per-area Spanish catalogs registered via `init()` (split per command to avoid one giant map).
- `cmd/mobiai/main.go`: `i18n.Init()` before tree build; `usageTemplate` const → function (headings resolve through `T()` at build time); `localizeHelpFlags()` localizes every subcommand's auto-generated `--help`.
- `internal/state/config.go` (new) + `paths.go`: persisted `Config{Lang}` at `config.json` (repurposed the unused `ConfigFile()` from `.toml` to `.json` — no TOML dep, matches meta/installed).
- `internal/cmd/*.go`, `internal/tui/*.go`: wrapped human-facing strings with `i18n.T(...)`.

## Test plan
- [x] `internal/i18n` tests: **TestCatalogCompleteness** (AST-scans every `i18n.T("...")` in the module, fails if any lacks an `es` translation — kills silent English fallback) and **TestCatalogVerbParity** (every en/es pair has identical ordered `%`-verbs).
- [x] `go build ./...`, `go vet ./...`, full suite (13 packages) — green. Default EN behavior unchanged (existing tests assert English and still pass).
- [x] Manual render pass: `--help` for every multi-line-`Long` subcommand in **both** en and es — no join bugs (double-spaces / run-ons) and no English stranded in Spanish prose.
- [x] Demo: `mobiai lang es` → help, `update` output, and accented text (á/ñ/ó) render correctly on the Windows console (UTF-8, no mojibake).

## Notes
- Bundled for the upcoming **0.2.2** release (alongside the binary self-update from #20).
- `TestCatalogCompleteness` guards *wrapped-without-translation*; it cannot detect a brand-new *unwrapped* user-facing string — the `51dcef2` diff is treated as the authoritative definition of the user-facing surface.
