### PR TITLE
feat(skills): pack community + CI guard de ownership

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,6 +55,13 @@
       "description": "Skills para React Native",
       "category": "platform",
       "tags": ["react-native", "javascript"]
+    },
+    {
+      "name": "community",
+      "source": "./skills/community",
+      "description": "Skills aportadas por la comunidad. Abierto a PRs de cualquiera; los packs de plataforma los curan los maintainers.",
+      "category": "community",
+      "tags": ["community", "contributed"]
     }
   ]
 }

--- a/.github/workflows/check-skills-docs.yml
+++ b/.github/workflows/check-skills-docs.yml
@@ -48,14 +48,18 @@ jobs:
           echo
 
           # Qué archivos cuentan como "documentación de skills".
+          # skills/community/README.md es el catálogo de la comunidad: editarlo
+          # alcanza para documentar una skill de community (los contribuyentes
+          # externos no pueden tocar el catálogo central del core).
           touched_docs=$(echo "$changed" \
-            | grep -E '^(README\.md|CONTRIBUTING\.md|docs/.+\.md|skills/core/skills/using-mobiai/SKILL\.md)$' \
+            | grep -E '^(README\.md|CONTRIBUTING\.md|docs/.+\.md|skills/core/skills/using-mobiai/SKILL\.md|skills/community/README\.md)$' \
             || true)
 
           if [ -z "$touched_docs" ]; then
             echo "::error::This PR adds or modifies skills but does not touch documentation."
             echo
             echo "When you add or change a skill, also update at least one of:"
+            echo "  • skills/community/README.md                (community catalog — for community skills)"
             echo "  • skills/core/skills/using-mobiai/SKILL.md  (central catalog)"
             echo "  • README.md                                 (available skills table)"
             echo "  • CONTRIBUTING.md                           (if you changed how to contribute)"

--- a/.github/workflows/guard-community-skills.yml
+++ b/.github/workflows/guard-community-skills.yml
@@ -1,0 +1,80 @@
+name: Guard skill ownership
+
+# Solo los maintainers pueden agregar o modificar skills FUERA de
+# `skills/community/`. Cualquier otra persona puede contribuir libremente,
+# pero únicamente dentro de `skills/community/`. Los packs de plataforma
+# (core, android, ios, kmp, flutter, react-native) quedan curados.
+#
+# Este check da feedback visible en el PR. No es un bloqueo absoluto por sí
+# solo: para convertirlo en un gate real, marcalo como required check en
+# branch protection (Settings → Branches). Aun así, quien tenga permiso de
+# merge puede saltearlo — por eso el allowlist coincide con quienes mergean.
+
+on:
+  pull_request:
+
+# Solo lectura: comparamos paths y el autor del PR, no escribimos nada.
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    env:
+      # Maintainers con permiso de merge. Mantené esta lista en sync con los
+      # colaboradores del repo (separados por espacios, case-insensitive).
+      MAINTAINERS: "ArisGuimera MatiRosen"
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout (with history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Only maintainers may touch non-community skills
+        run: |
+          set -euo pipefail
+
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          # Cambios de skills que NO están en community y NO son los skills de
+          # Google vendoreados (esos se sincronizan automáticamente vía bot PR
+          # desde upstream — ver sync-android-skills.yml).
+          protected=$(echo "$changed" \
+            | grep -E '^skills/' \
+            | grep -vE '^skills/community/' \
+            | grep -vE '^skills/android/skills/google/' \
+            || true)
+
+          if [ -z "$protected" ]; then
+            echo "No non-community skill changes — anyone can contribute here. ✓"
+            exit 0
+          fi
+
+          echo "Non-community skill files changed in this PR:"
+          echo "$protected" | sed 's/^/  - /'
+          echo
+
+          # ¿El autor del PR es maintainer? (case-insensitive)
+          author_lc=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+          for m in $MAINTAINERS; do
+            if [ "$author_lc" = "$(echo "$m" | tr '[:upper:]' '[:lower:]')" ]; then
+              echo "Author @$PR_AUTHOR is a maintainer — allowed. ✓"
+              exit 0
+            fi
+          done
+
+          echo "::error::@$PR_AUTHOR cannot modify skills outside skills/community/."
+          echo
+          echo "Only the maintainers ($MAINTAINERS) can change the curated packs"
+          echo "(core, android, ios, kmp, flutter, react-native)."
+          echo
+          echo "If you're contributing a new skill, put it under skills/community/"
+          echo "and register it in skills/community/README.md — that area is open to"
+          echo "everyone. See CONTRIBUTING.md."
+          echo
+          echo "If your skill really belongs in a platform pack, open an issue or a"
+          echo "PR proposing it and a maintainer will land it."
+          exit 1

--- a/.github/workflows/guard-community-skills.yml
+++ b/.github/workflows/guard-community-skills.yml
@@ -39,13 +39,12 @@ jobs:
 
           changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
 
-          # Cambios de skills que NO están en community y NO son los skills de
-          # Google vendoreados (esos se sincronizan automáticamente vía bot PR
-          # desde upstream — ver sync-android-skills.yml).
+          # Cambios de skills que NO están en community. Cubre TODO skills/**
+          # (SKILL.md, plugin.json, references/, scripts/, READMEs curados…),
+          # no solo los SKILL.md: "modificar una skill" es más que su SKILL.md.
           protected=$(echo "$changed" \
             | grep -E '^skills/' \
             | grep -vE '^skills/community/' \
-            | grep -vE '^skills/android/skills/google/' \
             || true)
 
           if [ -z "$protected" ]; then
@@ -57,8 +56,19 @@ jobs:
           echo "$protected" | sed 's/^/  - /'
           echo
 
-          # ¿El autor del PR es maintainer? (case-insensitive)
           author_lc=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+
+          # Excepción acotada: el bot que sincroniza los skills vendoreados de
+          # Google abre su PR como github-actions[bot] y solo toca
+          # skills/android/skills/google/ (ver sync-android-skills.yml). Se le
+          # permite en vez de excluir ese path de forma incondicional — así un
+          # humano externo que edite a mano esos skills SÍ queda bloqueado.
+          if [ "$author_lc" = "github-actions[bot]" ]; then
+            echo "Author @$PR_AUTHOR is the upstream-sync bot — allowed. ✓"
+            exit 0
+          fi
+
+          # ¿El autor del PR es maintainer? (case-insensitive)
           for m in $MAINTAINERS; do
             if [ "$author_lc" = "$(echo "$m" | tr '[:upper:]' '[:lower:]')" ]; then
               echo "Author @$PR_AUTHOR is a maintainer — allowed. ✓"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,25 +7,18 @@
 ### 1. Añadir un nuevo Skill
 Consulta la [guía para crear skills](docs/crear-skills.md).
 
+Las contribuciones de la comunidad van al pack **`community`**. Es la única área abierta a todos: un guard de CI (`guard-community-skills`) bloquea los PRs que tocan los packs curados (`core`, `android`, `ios`, `kmp`, `flutter`, `react-native`) si no vienen de un maintainer. Si creés que tu skill debería vivir en un pack de plataforma, abrí un issue o un PR proponiéndolo y un maintainer lo integra.
+
 **Pasos rápidos:**
-1. Haz fork del repo
-2. Decidí a qué plugin va tu skill:
-   - Workflow cross-platform → `skills/core/skills/`
-   - Android-specific → `skills/android/skills/`
-   - iOS-specific → `skills/ios/skills/`
-   - KMP/Flutter/RN → `skills/kmp/skills/` | `skills/flutter/skills/` | `skills/react-native/skills/`
-3. Crea `skills/<plugin>/skills/nombre-de-tu-skill/SKILL.md`
-4. Añade tu skill a la tabla en `skills/core/skills/using-mobiai/SKILL.md`
-5. Pruébalo en un proyecto real
-6. Abre un PR
+1. Haz fork del repo y creá una rama (`feat/community-<tu-skill>`)
+2. Crea `skills/community/skills/nombre-de-tu-skill/SKILL.md`
+3. Registrala en la tabla de [`skills/community/README.md`](skills/community/README.md)
+4. Pruébalo en un proyecto real
+5. Abre un PR
 
-**Regla crítica:** los nombres de skill deben ser únicos en TODO el catálogo. Si tu skill es platform-specific, prefijá con la plataforma (`mobiai-android-build`, `mobiai-ios-build`).
+**Regla crítica:** los nombres de skill deben ser únicos en TODO el catálogo. Prefijá tu skill de community para que no colisione (`mobiai-community-<tema>`).
 
-**Docs obligatorias:** un workflow de CI (`check-skills-docs`) bloquea PRs que agreguen o modifiquen skills sin tocar también la documentación. Para que tu PR pase, actualizá al menos uno de:
-
-- `skills/core/skills/using-mobiai/SKILL.md` (catálogo central — lo más común al agregar una skill nueva)
-- `README.md` (tabla de skills disponibles)
-- `docs/*.md` (cualquier guía relevante)
+**Docs obligatorias:** un workflow de CI (`check-skills-docs`) bloquea PRs que agreguen o modifiquen skills sin tocar también la documentación. Para una skill de community alcanza con actualizar `skills/community/README.md`. (Para el resto del catálogo: `README.md`, `docs/*.md`, o `skills/core/skills/using-mobiai/SKILL.md`.)
 
 Los skills vendoreados de Google bajo `skills/android/skills/google/` están exentos: se sincronizan automáticamente desde upstream.
 

--- a/README.es.md
+++ b/README.es.md
@@ -85,7 +85,7 @@ Detalle completo de instalación, build local y releases en [cli/README.md](cli/
 
 ```bash
 mobiai             # banner + ayuda
-mobiai skills init # selector interactivo para elegir packs (mobile, android, ios, kmp, flutter, react-native)
+mobiai skills init # selector interactivo para elegir packs (mobile, android, ios, kmp, flutter, react-native, community)
 ```
 
 Mantener al día (`mobiai update` refresca el catálogo) y diagnóstico (`mobiai doctor`, `mobiai status`) viven dentro de la CLI — ver [cli/README.md](cli/README.md).
@@ -104,7 +104,7 @@ mobiai skills add mobile           # instala todo el stack
 mobiai skills list                 # qué tienes instalado
 ```
 
-Packs: `mobile`, `android`, `ios`, `kmp`, `flutter`, `react-native`. → [skills/README.md](skills/README.md)
+Packs: `mobile`, `android`, `ios`, `kmp`, `flutter`, `react-native`, `community`. → [skills/README.md](skills/README.md)
 
 ### 🔍 [Graph](docs/graph/README.md) — exploración semántica del código
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Full install details, local builds, and releases in [cli/README.md](cli/README.m
 
 ```bash
 mobiai             # banner + help
-mobiai skills init # interactive selector to pick packs (mobile, android, ios, kmp, flutter, react-native)
+mobiai skills init # interactive selector to pick packs (mobile, android, ios, kmp, flutter, react-native, community)
 ```
 
 Keeping things up to date (`mobiai update` refreshes the catalog and self-updates the binary) and diagnostics (`mobiai doctor`, `mobiai status`) live inside the CLI — see [cli/README.md](cli/README.md).
@@ -104,7 +104,7 @@ mobiai skills add mobile           # install the whole stack
 mobiai skills list                 # what you have installed
 ```
 
-Packs: `mobile`, `android`, `ios`, `kmp`, `flutter`, `react-native`. → [skills/README.md](skills/README.md)
+Packs: `mobile`, `android`, `ios`, `kmp`, `flutter`, `react-native`, `community`. → [skills/README.md](skills/README.md)
 
 ### 🔍 [Graph](docs/graph/README.md) — semantic code exploration
 

--- a/docs/crear-skills.md
+++ b/docs/crear-skills.md
@@ -33,6 +33,8 @@ Esto significa que:
 
 ### 1. Crea el directorio
 
+> **¿Contribuís desde la comunidad?** Tu skill va en `skills/community/skills/`. Es la única área abierta a todos: un guard de CI (`guard-community-skills`) bloquea los PRs de no-maintainers que tocan los packs de plataforma. Creá `skills/community/skills/mi-skill/` y seguí desde el paso 2. Lo de abajo aplica a los maintainers que curan los packs de plataforma.
+
 Primero decidí a qué plugin pertenece tu skill:
 
 - `skills/core/skills/` — workflow cross-platform (planning, debugging, tdd, etc.)
@@ -71,7 +73,8 @@ Mira los skills existentes como ejemplo — cada uno tiene la estructura que mej
 
 ### 3. Agrégalo al catálogo
 
-Añade tu skill a la tabla en `skills/core/skills/using-mobiai/SKILL.md`.
+- **Skill de community:** registrala en la tabla de [`skills/community/README.md`](../skills/community/README.md). (No edites el catálogo central del core: el guard lo bloquea para no-maintainers.)
+- **Skill de plataforma (maintainers):** añadila a la tabla en `skills/core/skills/using-mobiai/SKILL.md`.
 
 ### 4. Pruébalo
 

--- a/skills/README.es.md
+++ b/skills/README.es.md
@@ -33,6 +33,7 @@ skills/
 ├── kmp/               # depende de android + ios
 ├── flutter/           # depende de android + ios
 ├── react-native/      # depende de android + ios
+├── community/         # skills aportadas por la comunidad — abierto a todos
 └── mobile/            # meta-pack: trae todo lo de arriba
 ```
 
@@ -48,6 +49,7 @@ Cada pack contiene un `.claude-plugin/plugin.json` con metadatos y dependencias.
 | `kmp` | Skills de Kotlin Multiplatform | core, android, ios | `mobiai skills add kmp` |
 | `flutter` | Skills de Flutter / Dart | core, android, ios | `mobiai skills add flutter` |
 | `react-native` | Skills de React Native | core, android, ios | `mobiai skills add react-native` |
+| `community` | Skills aportadas por la comunidad — el único pack abierto a todos | core | `mobiai skills add community` |
 | `core` | ⚠️ Interno — skills cross-platform, bootstrap `using-mobiai` y `SessionStart` hook. No se instala suelto | — | — |
 
 > `core` se instala automáticamente como dependencia de cualquier otro pack. No lo elijas a mano.
@@ -143,9 +145,8 @@ La idea es que el asistente no improvise: si hay un skill que cubre la tarea, lo
 
 1. Lee la [guía para crear skills](../docs/crear-skills.md).
 2. Invoca el skill `mobiai-writing-skills` desde tu asistente — te lleva por la estructura, frontmatter e instrucciones accionables.
-3. Coloca el skill en el pack adecuado:
-   - Cross-platform o de proceso → `core/skills/`
-   - Específico de plataforma → `android/skills/`, `ios/skills/`, etc.
+3. Coloca el skill en `community/skills/` — es el pack abierto a todos. Registralo en [`community/README.md`](community/README.md).
+   - Los packs de plataforma (`core`, `android`, `ios`, …) los curan los maintainers; un guard de CI (`guard-community-skills`) bloquea los PRs de no-maintainers que los tocan. Si tu skill va en uno de ellos, proponelo vía issue.
 4. Abre un PR. El CI bloquea PRs que añaden o modifican skills sin actualizar la documentación correspondiente.
 
 Detalle de la guía de contribución general en [../CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/skills/README.es.md
+++ b/skills/README.es.md
@@ -33,8 +33,8 @@ skills/
 ├── kmp/               # depende de android + ios
 ├── flutter/           # depende de android + ios
 ├── react-native/      # depende de android + ios
-├── community/         # skills aportadas por la comunidad — abierto a todos
-└── mobile/            # meta-pack: trae todo lo de arriba
+├── mobile/            # meta-pack: trae todo lo de arriba
+└── community/         # skills aportadas por la comunidad — abierto a todos (no entra en mobile)
 ```
 
 Cada pack contiene un `.claude-plugin/plugin.json` con metadatos y dependencias. Las dependencias se resuelven automáticamente al instalar (por ejemplo, instalar `kmp` arrastra `core`, `android` e `ios`).

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,8 +33,8 @@ skills/
 ├── kmp/               # depends on android + ios
 ├── flutter/           # depends on android + ios
 ├── react-native/      # depends on android + ios
-├── community/         # community-contributed skills — open to everyone
-└── mobile/            # meta-pack: brings everything above
+├── mobile/            # meta-pack: brings everything above
+└── community/         # community-contributed skills — open to everyone (not part of mobile)
 ```
 
 Each pack contains a `.claude-plugin/plugin.json` with metadata and dependencies. Dependencies are resolved automatically on install (for example, installing `kmp` pulls in `core`, `android`, and `ios`).

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,6 +33,7 @@ skills/
 ├── kmp/               # depends on android + ios
 ├── flutter/           # depends on android + ios
 ├── react-native/      # depends on android + ios
+├── community/         # community-contributed skills — open to everyone
 └── mobile/            # meta-pack: brings everything above
 ```
 
@@ -48,6 +49,7 @@ Each pack contains a `.claude-plugin/plugin.json` with metadata and dependencies
 | `kmp` | Kotlin Multiplatform skills | core, android, ios | `mobiai skills add kmp` |
 | `flutter` | Flutter / Dart skills | core, android, ios | `mobiai skills add flutter` |
 | `react-native` | React Native skills | core, android, ios | `mobiai skills add react-native` |
+| `community` | Skills contributed by the community — the one pack open to everyone | core | `mobiai skills add community` |
 | `core` | ⚠️ Internal — cross-platform skills, `using-mobiai` bootstrap, and `SessionStart` hook. Not installed standalone | — | — |
 
 > `core` is installed automatically as a dependency of any other pack. Don't pick it manually.
@@ -143,9 +145,8 @@ The idea is that the assistant doesn't improvise: if there's a skill covering th
 
 1. Read the [skill-authoring guide](../docs/crear-skills.md).
 2. Invoke the `mobiai-writing-skills` skill from your assistant — it walks you through the structure, frontmatter, and actionable instructions.
-3. Place the skill in the right pack:
-   - Cross-platform or process → `core/skills/`
-   - Platform-specific → `android/skills/`, `ios/skills/`, etc.
+3. Place the skill under `community/skills/` — that's the pack open to everyone. Register it in [`community/README.md`](community/README.md).
+   - The platform packs (`core`, `android`, `ios`, …) are maintainer-curated; a CI guard (`guard-community-skills`) blocks non-maintainer PRs that touch them. If your skill belongs in one, propose it via an issue.
 4. Open a PR. CI blocks PRs that add or modify skills without updating the relevant documentation.
 
 General contribution guidance in [../CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/skills/community/.claude-plugin/plugin.json
+++ b/skills/community/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "community",
+  "description": "Skills aportadas por la comunidad. Cualquiera puede contribuir acá vía PR; los packs de plataforma quedan curados por los maintainers.",
+  "version": "1.0.0",
+  "author": {
+    "name": "MobiAI Community",
+    "url": "https://github.com/ArisGuimera/MobiAI-Core"
+  },
+  "homepage": "https://github.com/ArisGuimera/MobiAI-Core",
+  "repository": "https://github.com/ArisGuimera/MobiAI-Core",
+  "license": "MIT",
+  "keywords": ["community", "contributed", "mobile"],
+  "dependencies": ["core"],
+  "skills": ["./skills/"]
+}

--- a/skills/community/README.md
+++ b/skills/community/README.md
@@ -1,0 +1,31 @@
+# Community skills
+
+> Skills contributed by the MobiAI community. This is the **one pack anyone can add to** — the platform packs (`core`, `android`, `ios`, `kmp`, `flutter`, `react-native`) are curated by the maintainers and a CI guard blocks PRs that change them unless they come from a maintainer.
+
+Install it like any other pack:
+
+```bash
+mobiai skills add community
+```
+
+It pulls in `core` automatically, so a community skill is discoverable as soon as it's installed.
+
+## Catalog
+
+<!-- Add one row per skill you contribute. Keep it sorted by name. -->
+
+| Skill | What it does | Author |
+|---|---|---|
+| _none yet_ | Be the first — see below. | — |
+
+## Contribute a community skill
+
+1. Fork the repo and create a branch (`feat/community-<your-skill>`).
+2. Create `skills/community/skills/<your-skill-name>/SKILL.md`.
+   - The name must be **unique across the whole catalog**. Prefix it so it doesn't collide — e.g. `mobiai-community-<topic>`.
+   - Follow the [skill authoring guide](../../docs/crear-skills.md) and the quality checklist in [CONTRIBUTING.md](../../CONTRIBUTING.md).
+3. **Register it** by adding a row to the *Catalog* table above. Updating this file is what satisfies the `check-skills-docs` CI gate for community PRs — you don't need to touch the central catalog.
+4. Test it on a real project.
+5. Open a PR. A maintainer reviews and merges.
+
+You can only add or change files **under `skills/community/`**. If your idea belongs in a platform pack (Android, iOS, …) open an issue or PR proposing it — a maintainer will land it.


### PR DESCRIPTION
## Resumen

Agrega un pack **`community`** — como `mobile`/`android`/`ios`/etc — para que cualquiera pueda contribuir skills a la comunidad vía PR, y un **CI guard** que mantiene los packs de plataforma curados: solo los maintainers pueden tocar skills fuera de `skills/community/`.

## Qué incluye

**Pack `community`** (data, no toca el CLI en Go — el catálogo se descubre desde `marketplace.json` + `plugin.json`):
- `skills/community/.claude-plugin/plugin.json` — pack nuevo, depende de `core`, instalable con `mobiai skills add community`.
- `skills/community/README.md` — catálogo de skills de la comunidad + cómo contribuir. Es el punto de registro para los contributors (decoplado del catálogo central del core).
- Entrada en `marketplace.json` (`category: "community"`, dep `core`).

**CI guard** (`.github/workflows/guard-community-skills.yml`):
- Corre en cada `pull_request` (sin `paths:` filter → safe para marcarlo required check más adelante).
- Si un PR toca skills **fuera de `skills/community/`** y el autor no está en el allowlist de maintainers (`ArisGuimera`, `MatiRosen`) → **falla** con un mensaje que redirige a `community`.
- Excluye `skills/android/skills/google/` para no bloquear el PR automático del sync upstream (`sync-android-skills.yml`).

**Integración:**
- `check-skills-docs.yml` ahora acepta `skills/community/README.md` como documentación válida → un PR de community se autodocumenta sin tocar el core (que el guard le bloquearía).
- `CONTRIBUTING.md`, `skills/README.md`/`.es`, `README.md`/`.es` actualizados al flujo community-first.

## Verificación

- `go generate` + `go build` + `go vet` limpios; `go test ./...` (13 paquetes) en verde.
- `mobiai catalog list` → 8 packs, `community` resuelve a `core → community`.
- Selector (`tui.PackRows`) filtra por **nombre** (`core`), no por categoría → `community` aparece en `mobiai skills init`.
- Lógica del guard simulada localmente en 9 escenarios (community/core/android/google-bot/maintainer/case-insensitive/mixto): todos correctos.

## Caveats

Es un **CI guard advisory**, no un candado absoluto: el gate real es el merge manual de los maintainers. Un PR puede editar el propio workflow (el guard no protege `.github/`), y los contribuyentes nuevos quedan en `action_required` hasta que un maintainer aprueba el run. Para un bloqueo duro habría que sumar CODEOWNERS + branch protection (no incluido en este PR, por decisión).

🤖 Generated with [Claude Code](https://claude.com/claude-code)