### PR TITLE
feat(skills): selección por-skill de community en el picker y el CLI

### DIFF
--- a/cli/internal/catalog/catalog.go
+++ b/cli/internal/catalog/catalog.go
@@ -1,10 +1,17 @@
 package catalog
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// CommunityPack is the catalog name of the community pack — the only pack
+// whose skills are installable individually (the picker drills into it and the
+// CLI accepts `community/<skill-id>` specs). Every other pack installs whole.
+const CommunityPack = "community"
 
 // Catalog is the aggregated view: marketplace + every plugin manifest +
 // resolved skill list per pack. All file IO happens in Load.
@@ -24,8 +31,9 @@ type Pack struct {
 // Skill is a single skill discovered under a pack's skills directories.
 // AbsPath is the absolute path to the skill directory (parent of SKILL.md).
 type Skill struct {
-	ID      string // directory name (e.g., "using-mobiai")
-	AbsPath string
+	ID          string // directory name (e.g., "using-mobiai")
+	AbsPath     string
+	Description string // `description:` from SKILL.md frontmatter (may be empty)
 }
 
 // Load reads the marketplace and every plugin manifest under rootDir.
@@ -109,8 +117,47 @@ func (c *Catalog) Skills(p *Pack) ([]Skill, error) {
 				continue
 			}
 			seen[abs] = true
-			out = append(out, Skill{ID: e.Name(), AbsPath: abs})
+			out = append(out, Skill{
+				ID:          e.Name(),
+				AbsPath:     abs,
+				Description: readSkillDescription(filepath.Join(abs, "SKILL.md")),
+			})
 		}
 	}
 	return out, nil
+}
+
+// readSkillDescription extracts the `description:` value from a SKILL.md
+// YAML frontmatter block (the lines between the first two `---` markers).
+// It is intentionally tolerant: any IO/format problem yields an empty string
+// so skill enumeration never fails just because a description is missing.
+func readSkillDescription(skillMdPath string) string {
+	f, err := os.Open(skillMdPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	inFrontmatter := false
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if !inFrontmatter {
+			if trimmed == "---" {
+				inFrontmatter = true
+				continue
+			}
+			// No frontmatter at the top of the file → nothing to read.
+			return ""
+		}
+		if trimmed == "---" {
+			return "" // closed the block without finding a description
+		}
+		if rest, ok := strings.CutPrefix(line, "description:"); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
 }

--- a/cli/internal/catalog/catalog_test.go
+++ b/cli/internal/catalog/catalog_test.go
@@ -15,8 +15,34 @@ func TestLoad_Sample(t *testing.T) {
 	if c.Marketplace.Name != "mobiai" {
 		t.Errorf("Marketplace.Name: got %q, want %q", c.Marketplace.Name, "mobiai")
 	}
-	if len(c.Packs) != 4 {
-		t.Fatalf("Packs length: got %d, want 4", len(c.Packs))
+	if len(c.Packs) != 5 {
+		t.Fatalf("Packs length: got %d, want 5", len(c.Packs))
+	}
+}
+
+func TestCatalog_Skills_ReadsDescription(t *testing.T) {
+	root := filepath.Join("testdata", "sample")
+	c, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	comm, err := c.Get(CommunityPack)
+	if err != nil {
+		t.Fatalf("Get(community): %v", err)
+	}
+	skills, err := c.Skills(comm)
+	if err != nil {
+		t.Fatalf("Skills(community): %v", err)
+	}
+	if len(skills) != 3 {
+		t.Fatalf("community skills: got %d, want 3", len(skills))
+	}
+	// os.ReadDir yields entries alphabetically, so the fixture comes back sorted.
+	if skills[0].ID != "alpha-skill" {
+		t.Errorf("first skill: got %q, want alpha-skill", skills[0].ID)
+	}
+	if skills[0].Description != "first community fixture skill" {
+		t.Errorf("description: got %q, want %q", skills[0].Description, "first community fixture skill")
 	}
 }
 

--- a/cli/internal/catalog/marketplace_test.go
+++ b/cli/internal/catalog/marketplace_test.go
@@ -17,8 +17,8 @@ func TestLoadMarketplace_Sample(t *testing.T) {
 	if mp.Metadata.Version != "0.1.0" {
 		t.Errorf("Metadata.Version: got %q, want %q", mp.Metadata.Version, "0.1.0")
 	}
-	if len(mp.Plugins) != 4 {
-		t.Fatalf("Plugins length: got %d, want 4", len(mp.Plugins))
+	if len(mp.Plugins) != 5 {
+		t.Fatalf("Plugins length: got %d, want 5", len(mp.Plugins))
 	}
 	if mp.Plugins[0].Name != "core" {
 		t.Errorf("Plugins[0].Name: got %q, want %q", mp.Plugins[0].Name, "core")

--- a/cli/internal/catalog/testdata/sample/.claude-plugin/marketplace.json
+++ b/cli/internal/catalog/testdata/sample/.claude-plugin/marketplace.json
@@ -35,6 +35,13 @@
       "description": "KMP plugin (depends on android+ios)",
       "category": "platform",
       "tags": ["kmp"]
+    },
+    {
+      "name": "community",
+      "source": "./skills/community",
+      "description": "Community plugin (test fixture)",
+      "category": "community",
+      "tags": ["community"]
     }
   ]
 }

--- a/cli/internal/catalog/testdata/sample/skills/community/.claude-plugin/plugin.json
+++ b/cli/internal/catalog/testdata/sample/skills/community/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "community",
+  "description": "Community plugin (test fixture)",
+  "version": "1.0.0",
+  "dependencies": ["core"],
+  "skills": ["./skills/"]
+}

--- a/cli/internal/catalog/testdata/sample/skills/community/skills/alpha-skill/SKILL.md
+++ b/cli/internal/catalog/testdata/sample/skills/community/skills/alpha-skill/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: alpha-skill
+description: first community fixture skill
+---
+fixture body

--- a/cli/internal/catalog/testdata/sample/skills/community/skills/bravo-skill/SKILL.md
+++ b/cli/internal/catalog/testdata/sample/skills/community/skills/bravo-skill/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: bravo-skill
+description: second community fixture skill
+---
+fixture body

--- a/cli/internal/catalog/testdata/sample/skills/community/skills/charlie-skill/SKILL.md
+++ b/cli/internal/catalog/testdata/sample/skills/community/skills/charlie-skill/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: charlie-skill
+description: third community fixture skill
+---
+fixture body

--- a/cli/internal/cmd/skills.go
+++ b/cli/internal/cmd/skills.go
@@ -104,18 +104,39 @@ func NewSkillsCmd() *cobra.Command {
 	return root
 }
 
-func runSkillsAdd(cmd *cobra.Command, packs []string) error {
+func runSkillsAdd(cmd *cobra.Command, args []string) error {
 	g := flagsFromAnyCmd(cmd)
 
 	c, err := loadCatalog(g)
 	if err != nil {
 		return err
 	}
-	hosts, err := selectHosts(g)
+
+	packs, commSkills, bareCommunity := parseSkillArgs(args)
+	if bareCommunity {
+		// Bare `community` installs every community skill; per-skill specs are
+		// redundant, so drop them to avoid double-processing the same pack.
+		commSkills = nil
+	}
+	if len(commSkills) > 0 {
+		if err := validateCommunitySkills(c, commSkills); err != nil {
+			return err
+		}
+	}
+
+	// Resolve install order at the pack level. Per-skill community installs feed
+	// the resolver the "community" pack so its dep `core` lands first; the
+	// selected skill IDs are applied as a filter at install time.
+	resolveReq := append([]string(nil), packs...)
+	if len(commSkills) > 0 && !containsString(resolveReq, catalog.CommunityPack) {
+		resolveReq = append(resolveReq, catalog.CommunityPack)
+	}
+	order, err := resolver.Resolve(c, resolveReq)
 	if err != nil {
 		return err
 	}
-	order, err := resolver.Resolve(c, packs)
+
+	hosts, err := selectHosts(g)
 	if err != nil {
 		return err
 	}
@@ -135,6 +156,9 @@ func runSkillsAdd(cmd *cobra.Command, packs []string) error {
 	out := cmd.OutOrStdout()
 
 	if !g.Yes {
+		if len(commSkills) > 0 {
+			fmt.Fprintf(out, i18n.T("  Community skills (%d): %s\n"), len(commSkills), strings.Join(commSkills, ", "))
+		}
 		ok, err := confirmInstall(out, cmd.InOrStdin(), order, hosts)
 		if err != nil {
 			return err
@@ -151,12 +175,24 @@ func runSkillsAdd(cmd *cobra.Command, packs []string) error {
 		if err != nil {
 			return fmt.Errorf("enumerate skills for %s: %w", packName, err)
 		}
+		// Restrict the community pack to the requested skills (unless the user
+		// asked for the whole pack with a bare `community`).
+		perSkill := packName == catalog.CommunityPack && len(commSkills) > 0
+		if perSkill {
+			skills = filterCatalogSkills(skills, commSkills)
+		}
+		display := packName
+		if perSkill {
+			display = communityDisplay(skillIDsOf(skills))
+		}
 		for _, h := range hosts {
 			if err := h.Install(skills); err != nil {
 				return fmt.Errorf("install %s into %s: %w", packName, h.ID(), err)
 			}
-			installed.Add(packName, h.ID())
-			fmt.Fprintf(out, "✓ %s → %s\n", packName, h.Name())
+			for _, k := range stateKeysForInstall(packName, perSkill, commSkills) {
+				installed.Add(k, h.ID())
+			}
+			fmt.Fprintf(out, "✓ %s → %s\n", display, h.Name())
 		}
 	}
 	if err := installed.Save(paths); err != nil {
@@ -193,7 +229,7 @@ func confirmInstall(out io.Writer, in io.Reader, packs []string, hosts []host.Ho
 	return answer == "y" || answer == "yes" || answer == "s" || answer == "si" || answer == "sí", nil
 }
 
-func runSkillsRemove(cmd *cobra.Command, packs []string) error {
+func runSkillsRemove(cmd *cobra.Command, args []string) error {
 	g := flagsFromAnyCmd(cmd)
 
 	hosts, err := selectHosts(g)
@@ -214,6 +250,18 @@ func runSkillsRemove(cmd *cobra.Command, packs []string) error {
 	if err != nil {
 		return err
 	}
+
+	packs, commSkills, bareCommunity := parseSkillArgs(args)
+	if bareCommunity {
+		commSkills = nil // bare `community` removes every community skill
+	}
+	if len(commSkills) > 0 {
+		if err := validateCommunitySkills(c, commSkills); err != nil {
+			return err
+		}
+	}
+
+	// Whole-pack removals (a bare `community` removes all its skills here).
 	for _, packName := range packs {
 		pack, err := c.Get(packName)
 		if err != nil {
@@ -232,14 +280,154 @@ func runSkillsRemove(cmd *cobra.Command, packs []string) error {
 				return fmt.Errorf("uninstall %s from %s: %w", packName, h.ID(), err)
 			}
 			installed.Remove(packName, h.ID())
+			if packName == catalog.CommunityPack {
+				// Clear any per-skill "community/<id>" records for this host too.
+				removeCommunitySkillKeys(installed, h.ID())
+			}
 			fmt.Fprintf(out, "✓ %s ← %s\n", packName, h.Name())
 		}
 	}
+
+	// Per-skill community removals.
+	if len(commSkills) > 0 {
+		display := communityDisplay(commSkills)
+		for _, h := range hosts {
+			if err := h.Uninstall(commSkills); err != nil {
+				return fmt.Errorf("uninstall community skills from %s: %w", h.ID(), err)
+			}
+			for _, id := range commSkills {
+				installed.Remove(state.CommunitySkillKey(id), h.ID())
+			}
+			fmt.Fprintf(out, "✓ %s ← %s\n", display, h.Name())
+		}
+	}
+
 	if err := installed.Save(paths); err != nil {
 		return err
 	}
 	fmt.Fprintln(out, i18n.T("Done."))
 	return nil
+}
+
+// parseSkillArgs splits `skills add/remove` arguments into whole-pack names and
+// per-skill community specs. An argument of the form "community/<id>" selects a
+// single community skill; a bare "community" means the whole community pack and
+// sets bareCommunity so callers can apply all-skills behavior.
+func parseSkillArgs(args []string) (packs []string, communitySkills []string, bareCommunity bool) {
+	for _, a := range args {
+		if id, ok := strings.CutPrefix(a, catalog.CommunityPack+"/"); ok {
+			if id != "" {
+				communitySkills = append(communitySkills, id)
+			}
+			continue
+		}
+		if a == catalog.CommunityPack {
+			bareCommunity = true
+		}
+		packs = append(packs, a)
+	}
+	return packs, communitySkills, bareCommunity
+}
+
+// validateCommunitySkills ensures every requested community skill ID exists in
+// the catalog, returning a helpful error listing the available IDs otherwise.
+func validateCommunitySkills(c *catalog.Catalog, ids []string) error {
+	pack, err := c.Get(catalog.CommunityPack)
+	if err != nil {
+		return fmt.Errorf("the catalog has no %q pack", catalog.CommunityPack)
+	}
+	skills, err := c.Skills(pack)
+	if err != nil {
+		return err
+	}
+	available := make(map[string]bool, len(skills))
+	names := make([]string, 0, len(skills))
+	for _, s := range skills {
+		available[s.ID] = true
+		names = append(names, s.ID)
+	}
+	sort.Strings(names)
+	for _, id := range ids {
+		if available[id] {
+			continue
+		}
+		if len(names) == 0 {
+			return fmt.Errorf("community skill %q not found: the community pack has no skills yet", id)
+		}
+		return fmt.Errorf("community skill %q not found. Available: %s", id, strings.Join(names, ", "))
+	}
+	return nil
+}
+
+// filterCatalogSkills keeps only the skills whose ID is in ids (order preserved).
+func filterCatalogSkills(skills []catalog.Skill, ids []string) []catalog.Skill {
+	want := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		want[id] = true
+	}
+	out := make([]catalog.Skill, 0, len(ids))
+	for _, s := range skills {
+		if want[s.ID] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// stateKeysForInstall returns the installed.json keys to record for a freshly
+// installed pack. A per-skill community install records one "community/<id>" key
+// per skill; everything else records the bare pack name.
+func stateKeysForInstall(pack string, perSkill bool, communitySkills []string) []string {
+	if perSkill {
+		keys := make([]string, len(communitySkills))
+		for i, id := range communitySkills {
+			keys[i] = state.CommunitySkillKey(id)
+		}
+		return keys
+	}
+	return []string{pack}
+}
+
+// removeCommunitySkillKeys drops every per-skill "community/<id>" record for the
+// given host (used when the whole community pack is removed).
+func removeCommunitySkillKeys(installed *state.Installed, host string) {
+	var keys []string
+	for key := range installed.Packs {
+		if _, ok := state.ParseCommunitySkillKey(key); ok {
+			keys = append(keys, key)
+		}
+	}
+	for _, key := range keys {
+		installed.Remove(key, host)
+	}
+}
+
+// communityDisplay is the label printed for a per-skill community operation: a
+// single skill reads as "community/<id>"; several batch into "community (N skills)".
+func communityDisplay(ids []string) string {
+	if len(ids) == 1 {
+		return state.CommunitySkillKey(ids[0])
+	}
+	return fmt.Sprintf(i18n.T("community (%d skills)"), len(ids))
+}
+
+// skillIDsOf extracts the IDs from a slice of catalog skills.
+func skillIDsOf(skills []catalog.Skill) []string {
+	ids := make([]string, len(skills))
+	for i, s := range skills {
+		ids[i] = s.ID
+	}
+	return ids
+}
+
+// containsString reports whether s is in xs.
+func containsString(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // flagsFromAnyCmd reads global flags from cmd, preferring the local lookup

--- a/cli/internal/cmd/skills_test.go
+++ b/cli/internal/cmd/skills_test.go
@@ -6,7 +6,21 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 )
+
+// sampleCatalogRoot points at the on-disk fixture catalog, which (unlike the
+// real repo) has a community pack with skills (alpha/bravo/charlie-skill) to
+// exercise per-skill install/remove.
+func sampleCatalogRoot(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("..", "catalog", "testdata", "sample"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}
 
 // repoRootForFixture returns the path to the actual MobiAI-Core repo so we
 // test against the real catalog. From cli/internal/cmd/, we go up 3 dirs.
@@ -93,6 +107,129 @@ func TestSkillsRemove_RemovesInstalledPack(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", "mobiai-android-build")); !os.IsNotExist(err) {
 		t.Errorf("expected android skills removed; stat err: %v", err)
+	}
+}
+
+// communityTestHome wires up a temp HOME with a detectable Claude Code dir and
+// returns the temp path so callers can assert on installed skills/state.
+func communityTestHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("MOBIAI_HOME", filepath.Join(tmp, ".mobiai"))
+	if err := os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return tmp
+}
+
+func TestSkillsAdd_CommunitySingleSkill(t *testing.T) {
+	tmp := communityTestHome(t)
+	root := sampleCatalogRoot(t)
+
+	cmd := NewSkillsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"add", "community/alpha-skill", "--catalog-root", root, "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	// Only the requested skill is installed.
+	if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", "alpha-skill", "SKILL.md")); err != nil {
+		t.Errorf("alpha-skill should be installed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", "bravo-skill")); !os.IsNotExist(err) {
+		t.Errorf("bravo-skill should NOT be installed; stat err: %v", err)
+	}
+	// The community pack's dep (core) is installed too.
+	if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", "using-mobiai")); err != nil {
+		t.Errorf("core dep using-mobiai should be installed: %v", err)
+	}
+
+	// State records the composite key, not a bare "community".
+	paths, _ := state.NewPaths()
+	inst, _ := state.LoadInstalled(paths)
+	if hosts := inst.HostsFor(state.CommunitySkillKey("alpha-skill")); len(hosts) == 0 {
+		t.Errorf("installed.json should record community/alpha-skill; got %v", inst.Packs)
+	}
+	if _, ok := inst.Packs["community"]; ok {
+		t.Errorf("installed.json should not have a bare community key; got %v", inst.Packs)
+	}
+}
+
+func TestSkillsAdd_CommunityUnknownSkill(t *testing.T) {
+	communityTestHome(t)
+	root := sampleCatalogRoot(t)
+
+	cmd := NewSkillsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"add", "community/does-not-exist", "--catalog-root", root, "--yes"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected an error for an unknown community skill")
+	}
+}
+
+func TestSkillsAdd_BareCommunityInstallsAll(t *testing.T) {
+	tmp := communityTestHome(t)
+	root := sampleCatalogRoot(t)
+
+	cmd := NewSkillsCmd()
+	cmd.SetArgs([]string{"add", "community", "--catalog-root", root, "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	for _, id := range []string{"alpha-skill", "bravo-skill", "charlie-skill"} {
+		if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", id)); err != nil {
+			t.Errorf("bare community should install %s: %v", id, err)
+		}
+	}
+	// Bare community keeps the legacy whole-pack state key.
+	paths, _ := state.NewPaths()
+	inst, _ := state.LoadInstalled(paths)
+	if hosts := inst.HostsFor("community"); len(hosts) == 0 {
+		t.Errorf("bare community should record a community key; got %v", inst.Packs)
+	}
+}
+
+func TestSkillsRemove_CommunitySingleSkill(t *testing.T) {
+	tmp := communityTestHome(t)
+	root := sampleCatalogRoot(t)
+
+	addCmd := NewSkillsCmd()
+	addCmd.SetArgs([]string{"add", "community/alpha-skill", "community/bravo-skill", "--catalog-root", root, "--yes"})
+	if err := addCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	rmCmd := NewSkillsCmd()
+	var out bytes.Buffer
+	rmCmd.SetOut(&out)
+	rmCmd.SetErr(&out)
+	rmCmd.SetArgs([]string{"remove", "community/alpha-skill", "--catalog-root", root, "--yes"})
+	if err := rmCmd.Execute(); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", "alpha-skill")); !os.IsNotExist(err) {
+		t.Errorf("alpha-skill should be removed; stat err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", "bravo-skill", "SKILL.md")); err != nil {
+		t.Errorf("bravo-skill should remain installed: %v", err)
+	}
+
+	paths, _ := state.NewPaths()
+	inst, _ := state.LoadInstalled(paths)
+	if hosts := inst.HostsFor(state.CommunitySkillKey("alpha-skill")); len(hosts) != 0 {
+		t.Errorf("community/alpha-skill should be gone from state; got %v", hosts)
+	}
+	if hosts := inst.HostsFor(state.CommunitySkillKey("bravo-skill")); len(hosts) == 0 {
+		t.Errorf("community/bravo-skill should remain in state; got %v", inst.Packs)
 	}
 }
 

--- a/cli/internal/i18n/catalog_skills_es.go
+++ b/cli/internal/i18n/catalog_skills_es.go
@@ -14,9 +14,10 @@ func init() {
 		"No packs installed.":                             "No hay packs instalados.",
 		"Interactive picker to install/uninstall skills":  "Selector interactivo para instalar/desinstalar skills",
 		"Launches the TUI picker to choose skill packs and apply changes to detected clients (Claude Code, Cursor, Codex, etc).": "Lanza el picker TUI para elegir packs de skills y aplicar los cambios sobre los clientes detectados (Claude Code, Cursor, Codex, etc).",
-		"Cancelled.":        "Cancelado.",
-		"Done.":             "Listo.",
-		"Install plan:":     "Plan de instalación:",
-		"Continue? [y/N]: ": "¿Continuar? [y/N]: ",
+		"Cancelled.":                    "Cancelado.",
+		"Done.":                         "Listo.",
+		"Install plan:":                 "Plan de instalación:",
+		"Continue? [y/N]: ":             "¿Continuar? [y/N]: ",
+		"  Community skills (%d): %s\n": "  Skills de la comunidad (%d): %s\n",
 	})
 }

--- a/cli/internal/i18n/catalog_tui_es.go
+++ b/cli/internal/i18n/catalog_tui_es.go
@@ -7,7 +7,13 @@ func init() {
 
 		// ── internal/tui/view.go ─────────────────────────────────────────────
 		"Detected hosts (%d): %s": "Hosts detectados (%d): %s",
-		"↑↓ navigate  [space] change action  [enter] apply  [q] quit": "↑↓ navegar  [espacio] cambiar acción  [enter] aplicar  [q] salir",
+		"↑↓ navigate  [space] change action  [enter] apply  [q] quit":   "↑↓ navegar  [espacio] cambiar acción  [enter] aplicar  [q] salir",
+		"↑↓ navigate  [space] change action  [enter] apply  [esc] back": "↑↓ navegar  [espacio] cambiar acción  [enter] aplicar  [esc] volver",
+		"→ pick skills":                                 "→ elegí skills",
+		"Community skills":                              "Skills de la comunidad",
+		"No community skills available yet.":            "Todavía no hay skills de la comunidad.",
+		"[esc] back":                                    "[esc] volver",
+		"community (%d skills)":                         "community (%d skills)",
 		"Confirm changes":                               "Confirmar cambios",
 		"No pending changes.\n":                         "No hay cambios pendientes.\n",
 		"To install:\n":                                 "A instalar:\n",

--- a/cli/internal/state/installed.go
+++ b/cli/internal/state/installed.go
@@ -6,12 +6,32 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
+
+// communityKeyPrefix namespaces per-skill community entries inside the Packs
+// map. Community is the one pack installable skill-by-skill, so instead of a
+// bare "community" key we record "community/<skill-id>" per installed skill.
+// This lets `skills list`/`status` reflect partial installs for free.
+const communityKeyPrefix = "community/"
+
+// CommunitySkillKey returns the Packs-map key for an individual community
+// skill (e.g. "community/foo"). It is the single source of truth for the
+// composite-key format.
+func CommunitySkillKey(skillID string) string { return communityKeyPrefix + skillID }
+
+// ParseCommunitySkillKey reports whether key is a per-skill community entry and,
+// if so, returns the bare skill ID.
+func ParseCommunitySkillKey(key string) (skillID string, ok bool) {
+	return strings.CutPrefix(key, communityKeyPrefix)
+}
 
 // Installed tracks which packs are installed in which hosts.
 // Persisted as <state>/installed.json.
 type Installed struct {
-	// Packs maps pack name → list of host IDs (sorted).
+	// Packs maps pack name → list of host IDs (sorted). Community skills are
+	// recorded individually under "community/<skill-id>" keys (see
+	// CommunitySkillKey) rather than a single "community" key.
 	Packs map[string][]string `json:"packs"`
 }
 

--- a/cli/internal/state/installed_test.go
+++ b/cli/internal/state/installed_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+func TestCommunitySkillKey_RoundTrip(t *testing.T) {
+	key := CommunitySkillKey("foo")
+	if key != "community/foo" {
+		t.Errorf("CommunitySkillKey: got %q, want community/foo", key)
+	}
+	id, ok := ParseCommunitySkillKey(key)
+	if !ok || id != "foo" {
+		t.Errorf("ParseCommunitySkillKey(%q): got (%q, %v), want (foo, true)", key, id, ok)
+	}
+	if _, ok := ParseCommunitySkillKey("android"); ok {
+		t.Error("ParseCommunitySkillKey(android): a bare pack name must not parse as a community key")
+	}
+}
+
 func TestLoadInstalled_MissingFileReturnsEmpty(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("MOBIAI_HOME", tmp)

--- a/cli/internal/tui/tui.go
+++ b/cli/internal/tui/tui.go
@@ -3,6 +3,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -19,6 +20,7 @@ type Mode int
 
 const (
 	ModePicker Mode = iota
+	ModeCommunityPicker
 	ModeConfirm
 	ModeProgress
 	ModeResult
@@ -58,6 +60,13 @@ type Model struct {
 	mode   Mode
 	cursor int
 
+	// Community sub-picker: the community pack is the one pack installable
+	// skill-by-skill, so selecting it drills into ModeCommunityPicker instead
+	// of toggling the whole pack. subCursor indexes communitySkills there.
+	subCursor        int
+	communitySkills  []catalog.Skill   // community pack's skills, sorted by ID (cached)
+	communityActions map[string]Action // pending action per community skill ID
+
 	userActions   map[string]Action // pending action per pack (Install/Uninstall/None)
 	requiredByDep map[string]bool   // packs marked required because of dep expansion (Install only)
 
@@ -69,19 +78,37 @@ type Model struct {
 	width, height int
 }
 
-// installStep is one (pack, host, kind) tuple to apply.
+// installStep is one (pack, host, kind) tuple to apply. skillIDs, when
+// non-empty, restricts the step to a subset of the pack's skills — used for
+// per-skill community install/uninstall. Empty means "the whole pack" (every
+// platform pack, and bare-community installs, take this path unchanged).
 type installStep struct {
-	pack string
-	host string
-	kind stepKind
+	pack     string
+	host     string
+	kind     stepKind
+	skillIDs []string
+}
+
+// label is the human-facing name of the step shown in progress/result views.
+// A community step carrying a skill subset reads as "community/foo" (single)
+// or "community (N skills)" (batched), instead of the bare pack name.
+func (s installStep) label() string {
+	if s.pack == catalog.CommunityPack && len(s.skillIDs) > 0 {
+		if len(s.skillIDs) == 1 {
+			return state.CommunitySkillKey(s.skillIDs[0])
+		}
+		return fmt.Sprintf(i18n.T("community (%d skills)"), len(s.skillIDs))
+	}
+	return s.pack
 }
 
 // installStepDoneMsg is emitted by the install runner once a step finishes.
 type installStepDoneMsg struct {
-	pack string
-	host string
-	kind stepKind
-	err  error
+	pack     string
+	host     string
+	kind     stepKind
+	skillIDs []string
+	err      error
 }
 
 // NewModel builds the picker model from already-loaded catalog/state/hosts.
@@ -93,12 +120,32 @@ func NewModel(c *catalog.Catalog, s *state.Installed, paths state.Paths, hosts [
 		mode = ModeNoHosts
 	}
 	return Model{
-		catalog: c,
-		state:   s,
-		paths:   paths,
-		hosts:   hosts,
-		mode:    mode,
+		catalog:         c,
+		state:           s,
+		paths:           paths,
+		hosts:           hosts,
+		mode:            mode,
+		communitySkills: loadCommunitySkills(c),
 	}
+}
+
+// loadCommunitySkills returns the community pack's skills sorted by ID, or nil
+// if the catalog has no community pack. Cached at construction so the picker
+// doesn't hit disk on every render.
+func loadCommunitySkills(c *catalog.Catalog) []catalog.Skill {
+	if c == nil || !c.Has(catalog.CommunityPack) {
+		return nil
+	}
+	pack, err := c.Get(catalog.CommunityPack)
+	if err != nil {
+		return nil
+	}
+	skills, err := c.Skills(pack)
+	if err != nil {
+		return nil
+	}
+	sort.Slice(skills, func(i, j int) bool { return skills[i].ID < skills[j].ID })
+	return skills
 }
 
 // Mode returns the current screen.
@@ -114,6 +161,7 @@ type PackRow struct {
 	Action      Action   // pending action (None/Install/Uninstall)
 	Required    bool     // required because another Install-marked pack depends on it
 	InstalledIn []string // host IDs where it's already installed
+	IsCommunity bool     // community pack: drills into the per-skill sub-picker
 }
 
 // PackRows builds the list of rows shown in the picker, filtering out the
@@ -134,6 +182,7 @@ func (m Model) PackRows() []PackRow {
 			Deps:        append([]string(nil), p.Manifest.Dependencies...),
 			Action:      m.userActions[p.Ref.Name],
 			Required:    m.requiredByDep[p.Ref.Name],
+			IsCommunity: p.Ref.Name == catalog.CommunityPack,
 		}
 		if hosts, ok := m.state.Packs[p.Ref.Name]; ok {
 			row.InstalledIn = append([]string(nil), hosts...)
@@ -154,6 +203,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch m.mode {
 		case ModePicker:
 			return m.updatePicker(msg)
+		case ModeCommunityPicker:
+			return m.updateCommunityPicker(msg)
 		case ModeConfirm:
 			return m.updateConfirm(msg)
 		case ModeResult:
@@ -193,12 +244,19 @@ func (m Model) handleInstallStep(msg installStepDoneMsg) (tea.Model, tea.Cmd) {
 	} else if m.state != nil {
 		// Mirror the persistence behavior of `mobiai skills add/remove`: every
 		// successful (pack, host) is recorded in installed.json so that
-		// `mobiai status`/`skills list` reflect TUI changes too.
+		// `mobiai status`/`skills list` reflect TUI changes too. A community
+		// per-skill step records one "community/<id>" key per skill instead of
+		// a bare "community" key.
+		keys := stateKeysFor(msg.pack, msg.skillIDs)
 		switch msg.kind {
 		case stepUninstall:
-			m.state.Remove(msg.pack, msg.host)
+			for _, k := range keys {
+				m.state.Remove(k, msg.host)
+			}
 		default:
-			m.state.Add(msg.pack, msg.host)
+			for _, k := range keys {
+				m.state.Add(k, msg.host)
+			}
 		}
 	}
 	m.installDone++
@@ -214,14 +272,34 @@ func (m Model) handleInstallStep(msg installStepDoneMsg) (tea.Model, tea.Cmd) {
 	return m, m.runInstallStep(m.installDone)
 }
 
-// hasPendingActions reports whether the user has any non-None action queued.
+// hasPendingActions reports whether the user has any non-None action queued,
+// across both whole-pack actions and per-skill community actions.
 func (m Model) hasPendingActions() bool {
 	for _, a := range m.userActions {
 		if a != ActionNone {
 			return true
 		}
 	}
+	for _, a := range m.communityActions {
+		if a != ActionNone {
+			return true
+		}
+	}
 	return false
+}
+
+// stateKeysFor returns the installed.json keys a step writes. A community step
+// with a skill subset maps to one "community/<id>" key per skill; everything
+// else maps to the bare pack name.
+func stateKeysFor(pack string, skillIDs []string) []string {
+	if pack == catalog.CommunityPack && len(skillIDs) > 0 {
+		keys := make([]string, len(skillIDs))
+		for i, id := range skillIDs {
+			keys[i] = state.CommunitySkillKey(id)
+		}
+		return keys
+	}
+	return []string{pack}
 }
 
 // buildInstallPlan produces the full ordered list of (pack, host, kind)
@@ -243,21 +321,53 @@ func (m Model) buildInstallPlan() []installStep {
 		}
 	}
 
+	// Community per-skill actions (kept separate from whole-pack actions).
+	var commInstall, commUninstall []string
+	for id, act := range m.communityActions {
+		switch act {
+		case ActionInstall:
+			commInstall = append(commInstall, id)
+		case ActionUninstall:
+			commUninstall = append(commUninstall, id)
+		}
+	}
+	sort.Strings(commInstall)
+	sort.Strings(commUninstall)
+
+	// Resolve install order at the PACK level. When any community skill is
+	// being installed we feed the resolver the "community" pack (not a synthetic
+	// per-skill name it doesn't know) so its dep `core` installs first; the
+	// selected skill IDs ride along as a filter on the community step.
+	resolveReq := append([]string(nil), installs...)
+	if len(commInstall) > 0 {
+		resolveReq = append(resolveReq, catalog.CommunityPack)
+	}
+
 	var plan []installStep
-	if len(installs) > 0 {
-		order, err := resolver.Resolve(m.catalog, installs)
+	if len(resolveReq) > 0 {
+		order, err := resolver.Resolve(m.catalog, resolveReq)
 		if err != nil {
 			return nil
 		}
 		for _, packName := range order {
 			for _, h := range m.hosts {
-				plan = append(plan, installStep{pack: packName, host: h.ID(), kind: stepInstall})
+				step := installStep{pack: packName, host: h.ID(), kind: stepInstall}
+				if packName == catalog.CommunityPack {
+					step.skillIDs = commInstall
+				}
+				plan = append(plan, step)
 			}
 		}
 	}
 	for _, packName := range uninstalls {
 		for _, h := range m.hosts {
 			plan = append(plan, installStep{pack: packName, host: h.ID(), kind: stepUninstall})
+		}
+	}
+	// Community per-skill uninstalls (no transitive removal — listed skills only).
+	if len(commUninstall) > 0 {
+		for _, h := range m.hosts {
+			plan = append(plan, installStep{pack: catalog.CommunityPack, host: h.ID(), kind: stepUninstall, skillIDs: commUninstall})
 		}
 	}
 	return plan
@@ -268,6 +378,10 @@ func (m Model) runInstallStep(idx int) tea.Cmd {
 	hosts := m.hosts
 	c := m.catalog
 	return func() tea.Msg {
+		done := func(err error) tea.Msg {
+			return installStepDoneMsg{pack: step.pack, host: step.host, kind: step.kind, skillIDs: step.skillIDs, err: err}
+		}
+
 		var hostAdapter host.HostAdapter
 		for _, h := range hosts {
 			if h.ID() == step.host {
@@ -276,15 +390,19 @@ func (m Model) runInstallStep(idx int) tea.Cmd {
 			}
 		}
 		if hostAdapter == nil {
-			return installStepDoneMsg{pack: step.pack, host: step.host, kind: step.kind, err: fmt.Errorf("host %q not found", step.host)}
+			return done(fmt.Errorf("host %q not found", step.host))
 		}
 		pack, err := c.Get(step.pack)
 		if err != nil {
-			return installStepDoneMsg{pack: step.pack, host: step.host, kind: step.kind, err: err}
+			return done(err)
 		}
 		skills, err := c.Skills(pack)
 		if err != nil {
-			return installStepDoneMsg{pack: step.pack, host: step.host, kind: step.kind, err: err}
+			return done(err)
+		}
+		// Per-skill steps (community) restrict the operation to a subset.
+		if len(step.skillIDs) > 0 {
+			skills = filterSkillsByID(skills, step.skillIDs)
 		}
 		switch step.kind {
 		case stepUninstall:
@@ -293,15 +411,30 @@ func (m Model) runInstallStep(idx int) tea.Cmd {
 				ids[i] = s.ID
 			}
 			if err := hostAdapter.Uninstall(ids); err != nil {
-				return installStepDoneMsg{pack: step.pack, host: step.host, kind: step.kind, err: err}
+				return done(err)
 			}
 		default:
 			if err := hostAdapter.Install(skills); err != nil {
-				return installStepDoneMsg{pack: step.pack, host: step.host, kind: step.kind, err: err}
+				return done(err)
 			}
 		}
-		return installStepDoneMsg{pack: step.pack, host: step.host, kind: step.kind}
+		return done(nil)
 	}
+}
+
+// filterSkillsByID keeps only the skills whose ID is in ids, preserving order.
+func filterSkillsByID(skills []catalog.Skill, ids []string) []catalog.Skill {
+	want := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		want[id] = true
+	}
+	out := make([]catalog.Skill, 0, len(ids))
+	for _, s := range skills {
+		if want[s.ID] {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func (m Model) updatePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -319,9 +452,17 @@ func (m Model) updatePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case " ", "x":
 		if m.cursor < len(rows) {
+			if rows[m.cursor].IsCommunity {
+				return m.enterCommunityPicker(), nil
+			}
 			m = m.toggleAt(m.cursor)
 		}
 	case "enter":
+		// Parado en el row community, enter abre la sub-pantalla de skills
+		// (es el punto de entrada al selector por-skill), no aplica.
+		if m.cursor < len(rows) && rows[m.cursor].IsCommunity {
+			return m.enterCommunityPicker(), nil
+		}
 		// Si no hay acciones pendientes, auto-cyclear el pack bajo el
 		// cursor antes de transicionar. Matchea expectativa "estoy
 		// parado en kmp, le doy enter, instalo (o desinstalo) kmp"
@@ -332,6 +473,78 @@ func (m Model) updatePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.mode = ModeConfirm
 	}
 	return m, nil
+}
+
+// enterCommunityPicker switches to the per-skill community sub-picker with the
+// sub-cursor reset to the top.
+func (m Model) enterCommunityPicker() Model {
+	m.mode = ModeCommunityPicker
+	m.subCursor = 0
+	return m
+}
+
+// updateCommunityPicker drives the per-skill community sub-picker.
+//
+// Keys:
+//   - ↑↓/kj   move the sub-cursor
+//   - space/x toggle the skill under the cursor (None ↔ Install, or
+//     None ↔ Uninstall when already installed in every host)
+//   - enter   apply: go to confirm if anything is pending, else back to picker
+//   - esc/←/h back to the main picker, keeping the pending selections
+//   - q/ctrl+c quit
+func (m Model) updateCommunityPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	skills := m.communitySkills
+	switch msg.String() {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+	case "esc", "left", "h":
+		m.mode = ModePicker
+	case "up", "k":
+		if m.subCursor > 0 {
+			m.subCursor--
+		}
+	case "down", "j":
+		if m.subCursor < len(skills)-1 {
+			m.subCursor++
+		}
+	case " ", "x":
+		if m.subCursor < len(skills) {
+			m = m.toggleCommunityAt(m.subCursor)
+		}
+	case "enter":
+		if m.hasPendingActions() {
+			m.mode = ModeConfirm
+		} else {
+			m.mode = ModePicker
+		}
+	}
+	return m, nil
+}
+
+// toggleCommunityAt cycles the action on the community skill at index i (in
+// communitySkills order). Mirrors toggleAt's installed-aware cycle:
+//   - skill installed in every host → None ↔ Uninstall
+//   - otherwise                     → None ↔ Install
+func (m Model) toggleCommunityAt(i int) Model {
+	if m.communityActions == nil {
+		m.communityActions = map[string]Action{}
+	}
+	id := m.communitySkills[i].ID
+	current := m.communityActions[id]
+	hosts := m.state.HostsFor(state.CommunitySkillKey(id))
+	fullyInstalled := len(hosts) > 0 && len(hosts) == len(m.hosts)
+
+	switch current {
+	case ActionNone:
+		if fullyInstalled {
+			m.communityActions[id] = ActionUninstall
+		} else {
+			m.communityActions[id] = ActionInstall
+		}
+	default:
+		delete(m.communityActions, id)
+	}
+	return m
 }
 
 // toggleAt cycles the action on the pack at index i (in PackRows order)
@@ -395,6 +608,8 @@ func (m Model) View() string {
 		return i18n.T("No AI client detected.\nInstall Claude Code, Cursor, Gemini CLI or Codex and run `mobiai` again.\n")
 	case ModePicker:
 		return m.viewPicker()
+	case ModeCommunityPicker:
+		return m.viewCommunityPicker()
 	case ModeConfirm:
 		return m.viewConfirm()
 	case ModeProgress:

--- a/cli/internal/tui/tui_test.go
+++ b/cli/internal/tui/tui_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -115,8 +117,232 @@ func keyMsg(k string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeySpace}
 	case "enter":
 		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
 	}
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)}
+}
+
+// communityModel builds a picker model from the on-disk sample catalog, which
+// includes a community pack with three skills (alpha/bravo/charlie-skill). The
+// community sub-picker reads real skills off disk, so these tests can't use the
+// hand-built inline catalogs the other tests use.
+func communityModel(t *testing.T) Model {
+	t.Helper()
+	root := filepath.Join("..", "catalog", "testdata", "sample")
+	c, err := catalog.Load(root)
+	if err != nil {
+		t.Fatalf("load sample catalog: %v", err)
+	}
+	return NewModel(c, &state.Installed{Packs: map[string][]string{}}, state.Paths{}, []host.HostAdapter{stubHost{}})
+}
+
+// communityRowIndex returns the cursor index of the community row in the main
+// picker, or -1 if absent.
+func communityRowIndex(m Model) int {
+	for i, r := range m.PackRows() {
+		if r.IsCommunity {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestCommunityModel_CachesSkillsSorted(t *testing.T) {
+	m := communityModel(t)
+	if len(m.communitySkills) != 3 {
+		t.Fatalf("communitySkills: got %d, want 3", len(m.communitySkills))
+	}
+	if m.communitySkills[0].ID != "alpha-skill" || m.communitySkills[2].ID != "charlie-skill" {
+		t.Errorf("communitySkills not sorted: got %s..%s", m.communitySkills[0].ID, m.communitySkills[2].ID)
+	}
+	if m.communitySkills[0].Description != "first community fixture skill" {
+		t.Errorf("description not loaded: got %q", m.communitySkills[0].Description)
+	}
+}
+
+func TestUpdate_EnterOnCommunity_OpensSubPicker(t *testing.T) {
+	m := communityModel(t)
+	m.cursor = communityRowIndex(m)
+	if m.cursor < 0 {
+		t.Fatal("no community row found")
+	}
+	updated, _ := m.Update(keyMsg("enter"))
+	if updated.(Model).mode != ModeCommunityPicker {
+		t.Errorf("mode after enter on community: got %v, want ModeCommunityPicker", updated.(Model).mode)
+	}
+}
+
+func TestUpdate_SpaceOnCommunity_OpensSubPicker(t *testing.T) {
+	m := communityModel(t)
+	m.cursor = communityRowIndex(m)
+	updated, _ := m.Update(keyMsg("space"))
+	final := updated.(Model)
+	if final.mode != ModeCommunityPicker {
+		t.Errorf("mode after space on community: got %v, want ModeCommunityPicker", final.mode)
+	}
+	// Space on community must NOT toggle the whole pack as a user action.
+	if final.userActions[catalog.CommunityPack] != ActionNone {
+		t.Errorf("community pack should not be toggled at pack level; got %v", final.userActions)
+	}
+}
+
+func TestCommunitySubPicker_ToggleSelectsSkill(t *testing.T) {
+	m := communityModel(t)
+	m.mode = ModeCommunityPicker
+	m.subCursor = 0 // alpha-skill
+	updated, _ := m.Update(keyMsg("space"))
+	final := updated.(Model)
+	if final.communityActions["alpha-skill"] != ActionInstall {
+		t.Errorf("alpha-skill action after space: got %v, want ActionInstall", final.communityActions["alpha-skill"])
+	}
+	// Second space cycles back to None.
+	updated, _ = final.Update(keyMsg("space"))
+	if updated.(Model).communityActions["alpha-skill"] != ActionNone {
+		t.Errorf("second space should reset to None; got %v", updated.(Model).communityActions["alpha-skill"])
+	}
+}
+
+func TestCommunitySubPicker_EnterWithPendingGoesToConfirm(t *testing.T) {
+	m := communityModel(t)
+	m.mode = ModeCommunityPicker
+	m.communityActions = map[string]Action{"alpha-skill": ActionInstall}
+	updated, _ := m.Update(keyMsg("enter"))
+	if updated.(Model).mode != ModeConfirm {
+		t.Errorf("mode after enter with pending: got %v, want ModeConfirm", updated.(Model).mode)
+	}
+}
+
+func TestCommunitySubPicker_EscReturnsToPickerKeepingSelections(t *testing.T) {
+	m := communityModel(t)
+	m.mode = ModeCommunityPicker
+	m.communityActions = map[string]Action{"alpha-skill": ActionInstall}
+	updated, _ := m.Update(keyMsg("esc"))
+	final := updated.(Model)
+	if final.mode != ModePicker {
+		t.Errorf("mode after esc: got %v, want ModePicker", final.mode)
+	}
+	if final.communityActions["alpha-skill"] != ActionInstall {
+		t.Errorf("esc should keep pending selections; got %v", final.communityActions)
+	}
+}
+
+func TestCommunitySubPicker_ToggleInstalledSkill_MarksUninstall(t *testing.T) {
+	m := communityModel(t)
+	// alpha-skill is already installed in the only detected host.
+	m.state.Packs[state.CommunitySkillKey("alpha-skill")] = []string{"stub"}
+	m.mode = ModeCommunityPicker
+	m.subCursor = 0 // alpha-skill (sorted first)
+
+	updated, _ := m.Update(keyMsg("space"))
+	final := updated.(Model)
+	if final.communityActions["alpha-skill"] != ActionUninstall {
+		t.Fatalf("space on an installed community skill should mark Uninstall; got %v", final.communityActions["alpha-skill"])
+	}
+
+	plan := final.buildInstallPlan()
+	var sawUninstall bool
+	for _, s := range plan {
+		if s.pack == catalog.CommunityPack && s.kind == stepUninstall {
+			sawUninstall = true
+			if len(s.skillIDs) != 1 || s.skillIDs[0] != "alpha-skill" {
+				t.Errorf("uninstall step skillIDs: got %v, want [alpha-skill]", s.skillIDs)
+			}
+		}
+	}
+	if !sawUninstall {
+		t.Error("expected a community stepUninstall in the plan")
+	}
+}
+
+func TestBuildInstallPlan_CommunitySkill_PullsCoreAndFiltersStep(t *testing.T) {
+	m := communityModel(t)
+	m.communityActions = map[string]Action{"alpha-skill": ActionInstall}
+
+	plan := m.buildInstallPlan()
+	if len(plan) == 0 {
+		t.Fatal("expected non-empty plan")
+	}
+
+	var coreIdx, commIdx = -1, -1
+	for i, s := range plan {
+		switch s.pack {
+		case "core":
+			if s.kind == stepInstall {
+				coreIdx = i
+			}
+		case catalog.CommunityPack:
+			if s.kind == stepInstall {
+				commIdx = i
+				if len(s.skillIDs) != 1 || s.skillIDs[0] != "alpha-skill" {
+					t.Errorf("community step skillIDs: got %v, want [alpha-skill]", s.skillIDs)
+				}
+			}
+		}
+	}
+	if coreIdx < 0 {
+		t.Error("expected a core install step (community depends on core)")
+	}
+	if commIdx < 0 {
+		t.Fatal("expected a community install step")
+	}
+	if coreIdx > commIdx {
+		t.Errorf("core (%d) must install before community (%d)", coreIdx, commIdx)
+	}
+}
+
+func TestHandleInstallStep_CommunitySkill_RecordsCompositeKey(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MOBIAI_HOME", tmp)
+	paths, _ := state.NewPaths()
+	if err := paths.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &catalog.Catalog{Marketplace: &catalog.Marketplace{}}
+	c.Reindex()
+	installed := &state.Installed{Packs: map[string][]string{}}
+	m := NewModel(c, installed, paths, []host.HostAdapter{stubHost{}})
+	m.mode = ModeProgress
+	m.installPlan = []installStep{{pack: "community", host: "stub", kind: stepInstall, skillIDs: []string{"alpha-skill"}}}
+
+	updated, _ := m.Update(installStepDoneMsg{pack: "community", host: "stub", kind: stepInstall, skillIDs: []string{"alpha-skill"}})
+	final := updated.(Model)
+
+	if hosts := final.state.HostsFor(state.CommunitySkillKey("alpha-skill")); len(hosts) != 1 || hosts[0] != "stub" {
+		t.Errorf("community/alpha-skill state: got %v, want [stub]", hosts)
+	}
+	if _, ok := final.state.Packs["community"]; ok {
+		t.Errorf("must not write a bare community key; got %v", final.state.Packs)
+	}
+}
+
+func TestCommunityMarker_ReflectsInstallState(t *testing.T) {
+	m := communityModel(t)
+
+	// None installed → empty marker.
+	if got := m.communityMarker(); strings.ContainsAny(got, "✓~+-") {
+		t.Errorf("no-install marker should be empty-ish; got %q", got)
+	}
+
+	// One of three installed → partial "[~]".
+	m.state.Packs[state.CommunitySkillKey("alpha-skill")] = []string{"stub"}
+	if got := m.communityMarker(); !strings.Contains(got, "~") {
+		t.Errorf("partial marker: got %q, want a ~", got)
+	}
+
+	// All three installed in the only host → "[✓]".
+	m.state.Packs[state.CommunitySkillKey("bravo-skill")] = []string{"stub"}
+	m.state.Packs[state.CommunitySkillKey("charlie-skill")] = []string{"stub"}
+	if got := m.communityMarker(); !strings.Contains(got, "✓") {
+		t.Errorf("all-installed marker: got %q, want a ✓", got)
+	}
+
+	// A pending install takes priority → "[+]".
+	m.communityActions = map[string]Action{"alpha-skill": ActionInstall}
+	if got := m.communityMarker(); !strings.Contains(got, "+") {
+		t.Errorf("pending-install marker: got %q, want a +", got)
+	}
 }
 
 func sampleModel(t *testing.T) Model {

--- a/cli/internal/tui/view.go
+++ b/cli/internal/tui/view.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/ArisGuimera/MobiAI-Core/cli/internal/i18n"
+	"github.com/ArisGuimera/MobiAI-Core/cli/internal/state"
 )
 
 var (
@@ -29,17 +30,116 @@ func (m Model) viewPicker() string {
 	rows := m.PackRows()
 	for i, r := range rows {
 		marker := pickerMarker(r, len(m.hosts))
+		desc := r.Description
+		if r.IsCommunity {
+			// Community is the one pack you drill into to pick skills one by one;
+			// its marker reflects the per-skill selection/install state.
+			marker = m.communityMarker()
+			desc = strings.TrimSpace(desc + "  " + i18n.T("→ pick skills"))
+		}
 
 		prefix := "  "
 		if i == m.cursor {
 			prefix = cursorStyle.Render("▶ ")
 		}
-		line := fmt.Sprintf("%s%s %-14s %s", prefix, marker, r.Name, dimStyle.Render(r.Description))
+		line := fmt.Sprintf("%s%s %-14s %s", prefix, marker, r.Name, dimStyle.Render(desc))
 		b.WriteString(line + "\n")
 	}
 
 	b.WriteString("\n" + dimStyle.Render(i18n.T("↑↓ navigate  [space] change action  [enter] apply  [q] quit")) + "\n")
 	return b.String()
+}
+
+// viewCommunityPicker renders the per-skill community sub-picker: one toggleable
+// row per community skill, sorted alphabetically.
+func (m Model) viewCommunityPicker() string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(i18n.T("Community skills")) + "\n\n")
+
+	if len(m.communitySkills) == 0 {
+		b.WriteString(dimStyle.Render(i18n.T("No community skills available yet.")) + "\n")
+		b.WriteString("\n" + dimStyle.Render(i18n.T("[esc] back")) + "\n")
+		return b.String()
+	}
+
+	for i, s := range m.communitySkills {
+		marker := m.communitySkillMarker(s.ID)
+		prefix := "  "
+		if i == m.subCursor {
+			prefix = cursorStyle.Render("▶ ")
+		}
+		line := fmt.Sprintf("%s%s %-24s %s", prefix, marker, s.ID, dimStyle.Render(s.Description))
+		b.WriteString(line + "\n")
+	}
+
+	b.WriteString("\n" + dimStyle.Render(i18n.T("↑↓ navigate  [space] change action  [enter] apply  [esc] back")) + "\n")
+	return b.String()
+}
+
+// communityMarker is the marker for the community row in the main picker. It
+// aggregates the per-skill state: pending selections take priority, otherwise
+// it shows how many community skills are already installed.
+func (m Model) communityMarker() string {
+	var pi, pu int
+	for _, a := range m.communityActions {
+		switch a {
+		case ActionInstall:
+			pi++
+		case ActionUninstall:
+			pu++
+		}
+	}
+	switch {
+	case pi > 0 && pu == 0:
+		return checkboxStyle.Render("[+]")
+	case pu > 0 && pi == 0:
+		return removalStyle.Render("[-]")
+	case pi > 0 && pu > 0:
+		return checkboxStyle.Render("[~]")
+	}
+
+	total := len(m.communitySkills)
+	if total == 0 {
+		return "[ ]"
+	}
+	full, some := 0, 0
+	for _, s := range m.communitySkills {
+		hosts := m.state.HostsFor(state.CommunitySkillKey(s.ID))
+		if len(hosts) == 0 {
+			continue
+		}
+		some++
+		if len(hosts) == len(m.hosts) {
+			full++
+		}
+	}
+	switch {
+	case some == 0:
+		return "[ ]"
+	case full == total:
+		return checkboxStyle.Render("[✓]")
+	default:
+		return checkboxStyle.Render("[~]")
+	}
+}
+
+// communitySkillMarker is the per-skill marker inside the community sub-picker.
+func (m Model) communitySkillMarker(id string) string {
+	switch m.communityActions[id] {
+	case ActionInstall:
+		return checkboxStyle.Render("[+]")
+	case ActionUninstall:
+		return removalStyle.Render("[-]")
+	}
+	hosts := m.state.HostsFor(state.CommunitySkillKey(id))
+	switch {
+	case len(hosts) == 0:
+		return "[ ]"
+	case len(hosts) == len(m.hosts):
+		return checkboxStyle.Render("[✓]")
+	default:
+		return checkboxStyle.Render("[~]")
+	}
 }
 
 // pickerMarker returns the visual checkbox-like marker for a pack row,
@@ -85,6 +185,15 @@ func (m Model) viewConfirm() string {
 			uninstalls = append(uninstalls, name)
 		}
 	}
+	// Per-skill community changes render as "community/<id>" alongside packs.
+	for id, act := range m.communityActions {
+		switch act {
+		case ActionInstall:
+			installs = append(installs, state.CommunitySkillKey(id))
+		case ActionUninstall:
+			uninstalls = append(uninstalls, state.CommunitySkillKey(id))
+		}
+	}
 	sort.Strings(installs)
 	sort.Strings(uninstalls)
 
@@ -121,7 +230,7 @@ func (m Model) viewProgress() string {
 		} else if i == m.installDone {
 			marker = "⠋ "
 		}
-		b.WriteString(fmt.Sprintf("%s%s → %s\n", marker, s.pack, s.host))
+		b.WriteString(fmt.Sprintf("%s%s → %s\n", marker, s.label(), s.host))
 	}
 	return b.String()
 }
@@ -139,15 +248,21 @@ func (m Model) viewResult() string {
 		b.WriteString(fmt.Sprintf(i18n.T("⚠ Finished with %d errors\n\n"), len(m.installErrors)))
 	}
 
-	errBy := make(map[[2]string]error, len(m.installErrors))
+	// Key by (pack, host, kind): a community install and a community uninstall
+	// can target the same host, so pack+host alone would collide.
+	type errKey struct {
+		pack, host string
+		kind       stepKind
+	}
+	errBy := make(map[errKey]error, len(m.installErrors))
 	for _, e := range m.installErrors {
-		errBy[[2]string{e.pack, e.host}] = e.err
+		errBy[errKey{e.pack, e.host, e.kind}] = e.err
 	}
 	for _, s := range m.installPlan {
-		if err, bad := errBy[[2]string{s.pack, s.host}]; bad {
-			b.WriteString(fmt.Sprintf("%s%s → %s: %v\n", removalStyle.Render("✗ "), s.pack, s.host, err))
+		if err, bad := errBy[errKey{s.pack, s.host, s.kind}]; bad {
+			b.WriteString(fmt.Sprintf("%s%s → %s: %v\n", removalStyle.Render("✗ "), s.label(), s.host, err))
 		} else {
-			b.WriteString(fmt.Sprintf("%s%s → %s\n", checkboxStyle.Render("✓ "), s.pack, s.host))
+			b.WriteString(fmt.Sprintf("%s%s → %s\n", checkboxStyle.Render("✓ "), s.label(), s.host))
 		}
 	}
 


### PR DESCRIPTION
## Resumen
El pack `community` pasa de instalarse todo-o-nada a poder elegirse **skill por skill**, tanto en el picker interactivo como en el CLI. Los packs de plataforma (android, ios, kmp, …) no cambian: siguen instalándose enteros.

## Qué cambia para el usuario
- **Picker (TUI):** parado en el row `community`, `espacio`/`enter` abre una sub-pantalla con las skills de comunidad ordenadas alfabéticamente (con su descripción). Se eligen una a una igual que los packs de plataforma — `[+]` instalar, `[-]` desinstalar, `[✓]` ya instalada, `[~]` parcial. `enter` aplica, `esc` vuelve al picker conservando lo elegido.
- **CLI:** `mobiai skills add community/<skill>` y `mobiai skills remove community/<skill>`. `community` pelado mantiene el comportamiento actual (instala/saca todas) para CI y compat.

## Por qué cada cambio
- **El plan de instalación pasó a poder filtrar un subconjunto** (`installStep.skillIDs`): antes cada step instalaba el pack entero. Era el cambio de fondo necesario para instalar solo algunas skills de community.
- **Las dependencias se resuelven a nivel pack:** al resolver se le pasa `community` (no `community/<skill>`), así `core` se instala primero; el filtro de skills va aparte en el step. Evita que una key sintética rompa el resolver y deje todo sin instalar en silencio.
- **El estado usa keys `community/<skill>`** en `installed.json` en vez de una `community` pelada, para representar installs parciales y que `skills list`/`status` los reflejen sin código extra.
- **Descripción de cada skill** leída del frontmatter del SKILL.md (parser mínimo, sin dependencia YAML nueva) para mostrarla en la sub-pantalla.

## Archivos
- `catalog/catalog.go` — `Skill.Description` + lector de frontmatter; const `CommunityPack`.
- `state/installed.go` — helpers `CommunitySkillKey` / `ParseCommunitySkillKey`.
- `tui/tui.go`, `tui/view.go` — `ModeCommunityPicker`, sub-picker, plan con subset, markers y vistas.
- `cmd/skills.go` — parsing y validación de `community/<skill>` en add/remove.
- `i18n/catalog_tui_es.go`, `i18n/catalog_skills_es.go` — strings nuevos (EN source + ES).
- `catalog/testdata/sample/...` — fixture de comunidad (3 skills) para tests.

## Test Plan
- [x] Tests nuevos: catalog (description), state (keys), tui (drill-in, toggle, plan install+uninstall, markers), cmd (add/remove `community/<skill>`, skill inexistente, bare community).
- [x] `go test ./...` verde, `go vet ./...` limpio, gofmt aplicado.
- [x] Guards de i18n (traducción + verb parity) pasan.
- [x] Smoke manual del binario: add single/multi, error de skill desconocida, remove, `skills list`.

## Riesgo de regresión
- Bajo. Los packs de plataforma usan el mismo camino de antes (`skillIDs` vacío = pack entero).
- Las keys compuestas en `installed.json` se revisaron contra todos los consumidores (`skills list`, `status`, `doctor`): ninguno le pasa la key a `catalog.Get`.

## Nota
La sub-pantalla está **vacía hasta que se aporte una skill** bajo `skills/community/skills/` — ese directorio no tiene skills todavía. La plomería está completa y testeada; las 3 skills del diff son solo fixtures de test (viven en `testdata/`, no se instalan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
